### PR TITLE
changed % to \% in documentation

### DIFF
--- a/R/igvShiny.R
+++ b/R/igvShiny.R
@@ -25,7 +25,7 @@ state[["userAddedTracks"]] <- list()
 #' @aliases igvShiny
 #'
 #' @param options a list, with required elements 'genomeName' and 'initialLocus'
-#' @param width a character string, standard css notations, either e.g., "1000px" or "95%"
+#' @param width a character string, standard css notations, either e.g., "1000px" or "95\%"
 #' @param height a character string, needs to be an explicit pixel measure, e.g., "800px"
 #' @param elementId a character string, the html element id within which igv is created
 #' @param displayMode a character string, default "SQUISHED".
@@ -63,7 +63,7 @@ igvShiny <- function(options, width = NULL, height = NULL, elementId = NULL, dis
 #' @aliases igvShinyOutput
 #'
 #' @param outputId a character string, specifies the html element id
-#' @param width a character string, standard css notations, either e.g., "1000px" or "95%", "100%" by default
+#' @param width a character string, standard css notations, either e.g., "1000px" or "95\%", "100\%" by default
 #' @param height a character string, needs to be an explicit pixel measure, e.g., "800px", "400px" by default
 #'
 #' @return the created widget's html

--- a/man/igvShiny.Rd
+++ b/man/igvShiny.Rd
@@ -15,7 +15,7 @@ igvShiny(
 \arguments{
 \item{options}{a list, with required elements 'genomeName' and 'initialLocus'}
 
-\item{width}{a character string, standard css notations, either e.g., "1000px" or "95%"}
+\item{width}{a character string, standard css notations, either e.g., "1000px" or "95\%"}
 
 \item{height}{a character string, needs to be an explicit pixel measure, e.g., "800px"}
 

--- a/man/igvShinyOutput.Rd
+++ b/man/igvShinyOutput.Rd
@@ -9,7 +9,7 @@ igvShinyOutput(outputId, width = "100\%", height = "400px")
 \arguments{
 \item{outputId}{a character string, specifies the html element id}
 
-\item{width}{a character string, standard css notations, either e.g., "1000px" or "95%", "100%" by default}
+\item{width}{a character string, standard css notations, either e.g., "1000px" or "95\%", "100\%" by default}
 
 \item{height}{a character string, needs to be an explicit pixel measure, e.g., "800px", "400px" by default}
 }


### PR DESCRIPTION
I was unable to install this package - I got the error described here: https://stackoverflow.com/questions/39670646/r-github-package-w-devtools-warning-unknown-macro-item

Changing `%` to `\%` fixed the issue and I was able to install the package.