### PR TITLE
igvReady (and igv-igvReady) events sent to R at startup

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: igvShiny
 Title: igvShiny
-Version: 1.2.17
-Date: 2021-02-25
+Version: 1.3.1
+Date: 2021-03-04
 Author: Paul Shannon
 Maintainer: Paul Shannon <pshannon@systemsbiology.org>
 Description: igv.js as a shiny widget

--- a/R/igvShiny.R
+++ b/R/igvShiny.R
@@ -28,12 +28,14 @@ state[["userAddedTracks"]] <- list()
 #' @param height a character string, needs to be an explicit pixel measure, e.g., "800px"
 #' @param elementId a character string, the html element id within which igv is created
 #' @param displayMode a character string, default "SQUISHED".
+#' @param tracks a list of track specifications to be created and displayed at startup
 #'
 #' @return the created widget
 #'
 #' @export
 #'
-igvShiny <- function(options, width = NULL, height = NULL, elementId = NULL, displayMode="squished")
+igvShiny <- function(options, width = NULL, height = NULL, elementId = NULL,
+                     displayMode="squished", tracks=list())
 {
   supportedOptions <- c("genomeName", "initialLocus")
   stopifnot(all(supportedOptions %in% names(options)))
@@ -42,6 +44,7 @@ igvShiny <- function(options, width = NULL, height = NULL, elementId = NULL, dis
   state[["requestedHeight"]] <- height
 
   printf("--- ~/github/igvShiny/R/igvShiny ctor");
+  printf("  initial track count: %d", length(tracks))
 
   htmlwidgets::createWidget(
     name = 'igvShiny',
@@ -51,6 +54,9 @@ igvShiny <- function(options, width = NULL, height = NULL, elementId = NULL, dis
     package = 'igvShiny',
     elementId = elementId
     )
+
+
+
 
 } # igvShiny constructor
 #----------------------------------------------------------------------------------------------------
@@ -97,7 +103,9 @@ renderIgvShiny <- function(expr, env=parent.frame(), quoted = FALSE)
       expr <- substitute(expr)
       } # force quoted
 
-  htmlwidgets::shinyRenderWidget(expr, igvShinyOutput, env, quoted = TRUE)
+   x <- htmlwidgets::shinyRenderWidget(expr, igvShinyOutput, env, quoted = TRUE)
+   printf("--- leaving igvShiny.R, renderIgvShiny")
+   return(x)
 
 }
 #----------------------------------------------------------------------------------------------------

--- a/inst/demos/igvShinyDemo.R
+++ b/inst/demos/igvShinyDemo.R
@@ -1,7 +1,7 @@
 library(shiny)
 library(igvShiny)
 library(GenomicAlignments)
-library(htmlwidgets)
+library(later)
 #----------------------------------------------------------------------------------------------------
 # we need a local directory to write files - for instance, a vcf file representing a genomic
 # region of interest.  we then tell shiny about that directory, so that shiny's built-in http server
@@ -117,6 +117,12 @@ server = function(input, output, session) {
       removeUserAddedTracks(session, id="igvShiny_0")
       })
 
+    observeEvent(input$igvReady, {
+        printf("--- igvReady")
+        containerID <- input$igvReady
+        printf("igv ready, %s", containerID)
+        loadBedTrack(session, id=containerID, trackName="bed.ready", tbl=tbl.bed, color="red");
+        })
 
    observeEvent(input$trackClick, {
        printf("--- trackclick event")
@@ -158,16 +164,23 @@ server = function(input, output, session) {
       })
 
    genomes <- c("hg38", "hg19", "mm10", "tair10", "rhos")
-   loci <- c("chr5:88,466,402-89,135,305", "MEF2C", "Mef2c", "1:7,432,931-7,440,395", "NC_007494.2:370,757-378,078")
-   i <- 2
+   loci <- c("chr5:88,466,402-89,135,305",  "chr1:7,426,231-7,453,241", "MEF2C", "Mef2c",
+             "1:7,432,931-7,440,395", "NC_007494.2:370,757-378,078",
+             "chr1:6,575,383-8,304,088")
 
-   output$igvShiny_0 <- renderIgvShiny(
-     igvShiny(list(
-        genomeName=genomes[i],
-        initialLocus=loci[i],
-        displayMode="SQUISHED"
-        ))
-      )
+   output$igvShiny_0 <- renderIgvShiny({
+     cat("--- starting renderIgvShiny\n");
+     x <- igvShiny(list(genomeName=genomes[1],
+                        initialLocus=loci[7],
+                        displayMode="SQUISHED",
+                        tracks=list()
+                        ))
+     cat("--- ending renderIgvShiny\n");
+     #later(function() {
+     #    loadBedTrack(session, id="igvShiny_0", trackName="bed.start", tbl=tbl.bed, color="red");
+     #    }, 8)
+     return(x)
+     })
 
    #output$igvShiny.1 <- renderIgvShiny(
    #  igvShiny(list(

--- a/inst/htmlwidgets/igvShiny.js
+++ b/inst/htmlwidgets/igvShiny.js
@@ -82,6 +82,8 @@ HTMLWidgets.widget({
                    Shiny.setInputValue("trackClick", x, {priority: "event"})
                    return false; // undefined causes follow on display of standard popup
                    }); // on
+                Shiny.setInputValue("igvReady", htmlContainerID, {priority: "event"});
+                Shiny.setInputValue("igv-igvReady", htmlContainerID, {priority: "event"});
                 }); // then: promise fulflled
           },
       resize: function(width, height) {

--- a/man/igvShiny.Rd
+++ b/man/igvShiny.Rd
@@ -9,7 +9,8 @@ igvShiny(
   width = NULL,
   height = NULL,
   elementId = NULL,
-  displayMode = "squished"
+  displayMode = "squished",
+  tracks = list()
 )
 }
 \arguments{
@@ -22,6 +23,8 @@ igvShiny(
 \item{elementId}{a character string, the html element id within which igv is created}
 
 \item{displayMode}{a character string, default "SQUISHED".}
+
+\item{tracks}{a list of track specifications to be created and displayed at startup}
 }
 \value{
 the created widget


### PR DESCRIPTION
this supports loading additional tracks at widget startup, in a very simple way  - by sending an "igvReady" event to R after the promise returned by igvWidget.createBrowser returns.  

Any shiny app which observes this event then has the opportunity to add one or more tracks as they wish.     In a very simple loadBedTrack test (see ```inst/demos/igvShinyDemo.R```)  this works smoothly.