### PR TITLE
Fix module namespace in igvReady and trackClick events

### DIFF
--- a/R/igvShiny.R
+++ b/R/igvShiny.R
@@ -42,14 +42,14 @@ igvShiny <- function(options, width = NULL, height = NULL, elementId = NULL,
   supportedGenomes <- c("hg38", "hg19", "mm10", "tair10", "rhos")
   stopifnot(options$genomeName %in% supportedGenomes)
   state[["requestedHeight"]] <- height
-
+  
   printf("--- ~/github/igvShiny/R/igvShiny ctor");
   printf("  initial track count: %d", length(tracks))
   
   #send namespace info in case widget is being called from a module
   session <- shiny::getDefaultReactiveDomain()
   options$moduleNS <- session$ns("")
-
+  
   htmlwidgets::createWidget(
     name = 'igvShiny',
     options,
@@ -57,11 +57,11 @@ igvShiny <- function(options, width = NULL, height = NULL, elementId = NULL,
     height = height,
     package = 'igvShiny',
     elementId = elementId
-    )
-
-
-
-
+  )
+  
+  
+  
+  
 } # igvShiny constructor
 #----------------------------------------------------------------------------------------------------
 #' create the UI for the widget

--- a/inst/demos/igvShinyDemo-withModules.R
+++ b/inst/demos/igvShinyDemo-withModules.R
@@ -132,17 +132,17 @@ igv_server <-  function(input, output, session) {
        print(x)
    })
 
-   observeEvent(input[["igv-trackClick"]], {
-       printf("--- igv-trackClick event")
-       x <- input[["igv-trackClick"]]
-       print(x)
-       })
+   # observeEvent(input[["igv-trackClick"]], {
+   #     printf("--- igv-trackClick event")
+   #     x <- input[["igv-trackClick"]]
+   #     print(x)
+   #     })
 
    observeEvent(input$getChromLocButton, {
       # printf("--- getChromLoc event")
       # sends message to igv.js in browser; currentGenomicRegion.<id> event sent back
       # see below for how that can be captured and displayed
-      getGenomicRegion(session, id="igv-igvShiny_0")
+      getGenomicRegion(session, id=ns("igvShiny_0"))
       print(sprintf("getChromLocButton, currentGenomicRegion.%s", ns("igvShiny_0")))
       })
 
@@ -182,7 +182,7 @@ igv_server <-  function(input, output, session) {
 
 } # server
 #----------------------------------------------------------------------------------------------------
-print(sessionInfo())
+#print(sessionInfo())
 
 server <- function(input, output, session){
   callModule(igv_server, "igv")

--- a/inst/demos/igvShinyDemo-withModules.R
+++ b/inst/demos/igvShinyDemo-withModules.R
@@ -78,51 +78,51 @@ igv_server <-  function(input, output, session) {
       })
 
    observeEvent(input$addBedGraphTrackButton, {
-      showGenomicRegion(session, id="igvShiny_0", "chr1:7,426,231-7,453,241")
-      loadBedGraphTrack(session, id="igvShiny_0", trackName="wig", tbl=tbl.bed, color="blue", autoscale=TRUE)
+      showGenomicRegion(session, id=ns("igvShiny_0"), "chr1:7,426,231-7,453,241")
+      loadBedGraphTrack(session, id=ns("igvShiny_0"), trackName="wig", tbl=tbl.bed, color="blue", autoscale=TRUE)
       })
 
    observeEvent(input$addSegTrackButton, {
-      showGenomicRegion(session, id="igvShiny_0", "chr1:7,426,231-7,453,241")
-      loadSegTrack(session, id="igvShiny_0", trackName="seg", tbl=tbl.bed)
+      showGenomicRegion(session, id=ns("igvShiny_0"), "chr1:7,426,231-7,453,241")
+      loadSegTrack(session, id=ns("igvShiny_0"), trackName="seg", tbl=tbl.bed)
       })
 
    observeEvent(input$addGwasTrackButton, {
       printf("---- addGWASTrack")
       printf("current working directory: %s", getwd())
-      showGenomicRegion(session, id="igvShiny_0", "chr19:45,248,108-45,564,645")
-      loadGwasTrack(session, id="igvShiny_0", trackName="gwas", tbl=tbl.gwas, deleteTracksOfSameName=FALSE)
+      showGenomicRegion(session, id=ns("igvShiny_0"), "chr19:45,248,108-45,564,645")
+      loadGwasTrack(session, id=ns("igvShiny_0"), trackName="gwas", tbl=tbl.gwas, deleteTracksOfSameName=FALSE)
       })
 
    observeEvent(input$addBamViaHttpButton, {
       printf("---- addBamViaHttpTrack")
-      showGenomicRegion(session, id="igvShiny_0", "chr5:88,733,959-88,761,606")
+      showGenomicRegion(session, id=ns("igvShiny_0"), "chr5:88,733,959-88,761,606")
       base.url <- "https://1000genomes.s3.amazonaws.com/phase3/data/HG02450/alignment"
       url <- sprintf("%s/%s", base.url, "HG02450.mapped.ILLUMINA.bwa.ACB.low_coverage.20120522.bam")
       indexURL <- sprintf("%s/%s", base.url, "HG02450.mapped.ILLUMINA.bwa.ACB.low_coverage.20120522.bam.bai")
-      loadBamTrackFromURL(session, id="igvShiny_0",trackName="1kg.bam", bamURL=url, indexURL=indexURL)
+      loadBamTrackFromURL(session, id=ns("igvShiny_0"),trackName="1kg.bam", bamURL=url, indexURL=indexURL)
       })
 
    observeEvent(input$addBamLocalFileButton, {
       printf("---- addBamLocalFileButton")
-      showGenomicRegion(session, id="igvShiny_0", "chr21:10,397,614-10,423,341")
+      showGenomicRegion(session, id=ns("igvShiny_0"), "chr21:10,397,614-10,423,341")
       bamFile <- system.file(package="igvShiny", "extdata", "tumor.bam")
       x <- readGAlignments(bamFile)
-      loadBamTrackFromLocalData(session, id="igvShiny_0", trackName="tumor.bam", data=x)
+      loadBamTrackFromLocalData(session, id=ns("igvShiny_0"), trackName="tumor.bam", data=x)
       })
 
    observeEvent(input$addCramViaHttpButton, {
       printf("---- addCramViaHttpTrack")
-      showGenomicRegion(session, id="igvShiny_0", "chr5:88,733,959-88,761,606")
+      showGenomicRegion(session, id=ns("igvShiny_0"), "chr5:88,733,959-88,761,606")
       base.url <- "https://s3.amazonaws.com/1000genomes/phase3/data/HG00096/exome_alignment"
       url <- sprintf("%s/%s", base.url, "HG00096.mapped.ILLUMINA.bwa.GBR.exome.20120522.bam.cram")
       indexURL <- sprintf("%s/%s", base.url, "HG00096.mapped.ILLUMINA.bwa.GBR.exome.20120522.bam.cram.crai")
-      loadCramTrackFromURL(session, id="igvShiny_0",trackName="CRAM", cramURL=url, indexURL=indexURL)
+      loadCramTrackFromURL(session, id=ns("igvShiny_0"),trackName="CRAM", cramURL=url, indexURL=indexURL)
       })
 
    observeEvent(input$removeUserTracksButton, {
       printf("---- removeUserTracks")
-      removeUserAddedTracks(session, id="igvShiny_0")
+      removeUserAddedTracks(session, id=ns("igvShiny_0"))
       })
 
 
@@ -131,12 +131,6 @@ igv_server <-  function(input, output, session) {
        x <- input$trackClick
        print(x)
    })
-
-   # observeEvent(input[["igv-trackClick"]], {
-   #     printf("--- igv-trackClick event")
-   #     x <- input[["igv-trackClick"]]
-   #     print(x)
-   #     })
 
    observeEvent(input$getChromLocButton, {
       # printf("--- getChromLoc event")
@@ -182,7 +176,7 @@ igv_server <-  function(input, output, session) {
 
 } # server
 #----------------------------------------------------------------------------------------------------
-#print(sessionInfo())
+print(sessionInfo())
 
 server <- function(input, output, session){
   callModule(igv_server, "igv")

--- a/inst/htmlwidgets/igvShiny.js
+++ b/inst/htmlwidgets/igvShiny.js
@@ -70,8 +70,8 @@ HTMLWidgets.widget({
    		   console.log("eventName: " + eventName);
                    console.log("chromLocString: " + chromLocString);
                    Shiny.setInputValue(eventName, chromLocString, {priority: "event"});
-//                   var moduleEventName = "igv-currentGenomicRegion." + htmlContainerID.replace("igv-", "");
-                    var moduleEventName = moduleNamespace(options.moduleNS, "currentGenomicRegion.") + htmlContainerID.replace(options.moduleNS, "");
+       //            var moduleEventName = "igv-currentGenomicRegion." + htmlContainerID.replace("igv-", "");
+                  var moduleEventName = moduleNamespace(options.moduleNS, "currentGenomicRegion.") + htmlContainerID.replace(options.moduleNS, "");
    		   console.log("moduleEventName: " + moduleEventName);
                    Shiny.setInputValue(moduleEventName, chromLocString, {priority: "event"});
                  }, 250, false));
@@ -79,13 +79,13 @@ HTMLWidgets.widget({
                    var x = popoverData;
                    console.log(x)
                        // prepend module namespace to support the github/shinyModules/igvModule.R
-                   Shiny.setInputValue(moduleNamespace(options.moduleNS, "trackClick", x, {priority: "event"}))
+                   Shiny.setInputValue(moduleNamespace(options.moduleNS, "trackClick"), x, {priority: "event"})
                        // for use outside of the ShinyModule idiom
                    Shiny.setInputValue("trackClick", x, {priority: "event"})
                    return false; // undefined causes follow on display of standard popup
                    }); // on
                 Shiny.setInputValue("igvReady", htmlContainerID, {priority: "event"});
-                Shiny.setInputValue(moduleNamespace(options.moduleNS, "igvReady", htmlContainerID, {priority: "event"}));
+                Shiny.setInputValue(moduleNamespace(options.moduleNS, "igvReady"), htmlContainerID, {priority: "event"});
                 }); // then: promise fulflled
           },
       resize: function(width, height) {


### PR DESCRIPTION
`igvReady` and `trackClick` were not working in igvShiny inside a Shiny module, and this PR fixes this issue.