### PR TITLE
Improve load time

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: igvShiny
 Title: igvShiny
-Version: 1.5.9002
-Date: 2022-11-17
+Version: 1.5.9003
+Date: 2022-12-28
 Author: Paul Shannon
 Maintainer: Paul Shannon <paul.thurmond.shannon@gmail.com>
 Description: igv.js as a shiny widget

--- a/R/genomeSpec.R
+++ b/R/genomeSpec.R
@@ -68,6 +68,7 @@ currently.supported.stock.genomes <- function(test=FALSE)
 #'     essential for all but the very small custom genomes.
 #' @param genomeAnnotation character when supplying a custom (non-stock) genome, a file path or URL pointing
 #'    to a genome annotation file in a gff3 format
+#' @param ... optional parameters for currently.supported.stock.genomes()
 #'
 #' @examples
 #' genomeSpec <- parseAndValidateGenomeSpec("hg38", "APOE")  # the simplest case
@@ -91,7 +92,7 @@ currently.supported.stock.genomes <- function(test=FALSE)
 #'
 parseAndValidateGenomeSpec <- function(genomeName, initialLocus="all",
                                        stockGenome=TRUE,
-                                       dataMode=NA, fasta=NA, fastaIndex=NA, genomeAnnotation=NA)
+                                       dataMode=NA, fasta=NA, fastaIndex=NA, genomeAnnotation=NA, ...)
 {
     options <- list()
     options[["stockGenome"]] <- stockGenome
@@ -104,7 +105,7 @@ parseAndValidateGenomeSpec <- function(genomeName, initialLocus="all",
     #--------------------------------------------------
 
     if(stockGenome){
-       supported.stock.genomes <- currently.supported.stock.genomes()
+       supported.stock.genomes <- currently.supported.stock.genomes(...)
        if(!genomeName %in% supported.stock.genomes){
           s.1 <- sprintf("Your genome '%s' is not currently supported", genomeName)
           s.2 <- sprintf("Currently supported: %s", paste(supported.stock.genomes, collapse=","))

--- a/man/parseAndValidateGenomeSpec.Rd
+++ b/man/parseAndValidateGenomeSpec.Rd
@@ -11,7 +11,8 @@ parseAndValidateGenomeSpec(
   dataMode = NA,
   fasta = NA,
   fastaIndex = NA,
-  genomeAnnotation = NA
+  genomeAnnotation = NA,
+  ...
 )
 }
 \arguments{
@@ -31,6 +32,8 @@ essential for all but the very small custom genomes.}
 
 \item{genomeAnnotation}{character when supplying a custom (non-stock) genome, a file path or URL pointing
 to a genome annotation file in a gff3 format}
+
+\item{...}{optional parameters for currently.supported.stock.genomes()}
 }
 \value{
 an options list directly usable by igvApp.js, and thus igv.js


### PR DESCRIPTION
Hi,

I believe that many users work with 'hg38' or 'mm10' reference genomes. For them, running the shiny module with test genomes will suffice.
```
parseAndValidateGenomeSpec <- function("mm10", initialLocus="all", test = TRUE)
```

This small PR introduces support for such cases. The improvement in the load time of the Shiny module is noticeable. 
Here is the key benchmark of the `parseAndValidateGenomeSpec` with `test` set to `FALSE` (default) and `TRUE` (50x difference).
```
microbenchmark::microbenchmark(
  {igvShiny::parseAndValidateGenomeSpec(genomeName = "mm10", initialLocus = "all", test = TRUE)},
  setup = {igvShiny::parseAndValidateGenomeSpec(genomeName = "hg38", initialLocus = "all", test = TRUE)},
  times = 3,
  unit = "ms")
# min   lq  mean  median    uq    max    neval
# 18.2 18.2 19.1   18.2     19.55 20.9     3

microbenchmark::microbenchmark(
  {igvShiny::parseAndValidateGenomeSpec(genomeName = "mm10", initialLocus = "all", test = FALSE)},
  setup = {igvShiny::parseAndValidateGenomeSpec(genomeName = "hg38", initialLocus = "all", test = TRUE)},
  times = 3,
  unit = "ms")
# min       lq     mean      median  uq       max       neval
# 1026.681 1029.96 1204.271 1033.239 1293.066 1552.894  3
```

I believe this might also improve the robustness (no dependency on the data from Amazon AWS).
