### PR TITLE
fix: pass autoscaleGroup through in loadBedGraphTrackFromURL (#105)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.3
-Date: 2024-08-29
+Version: 1.9.4
+Date: 2026-07-03
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 
     email = "paul.thurmond.shannon@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## igvShiny 1.9.4
+* fix: pass `autoscaleGroup` through in `loadBedGraphTrackFromURL` (#105, thanks @M4teuszzGl4dki)
+* fix: support string-based `autoscaleGroup` values in both bedGraph handlers
+
 ## igvShiny 1.9.3
 * ci: fix Windows/macOS CI failures (install pkgload alongside pkgdown)
 * ci: add automated push to Bioconductor devel on merge to master

--- a/inst/htmlwidgets/igvShiny.js
+++ b/inst/htmlwidgets/igvShiny.js
@@ -502,7 +502,7 @@ Shiny.addCustomMessageHandler("loadBedGraphTrack",
                     max: max
                     };
       config = mergeExtraParameters(config, message);
-      if(autoscaleGroup >= 0)
+      if(autoscaleGroup !== -1 && autoscaleGroup !== undefined && autoscaleGroup !== null)
           config['autoscaleGroup'] = autoscaleGroup;
       console.log("--- loading bedGraphTrack");
       console.log(config)
@@ -549,7 +549,7 @@ Shiny.addCustomMessageHandler("loadBedGraphTrackFromURL",
       console.log("--- loading bedGraphTrackFromURL");
       console.log(config)
       config = mergeExtraParameters(config, message);
-      if(autoscaleGroup >= 0)
+      if(autoscaleGroup !== -1 && autoscaleGroup !== undefined && autoscaleGroup !== null)
           config['autoscaleGroup'] = autoscaleGroup;
       igvBrowser.loadTrack(config);
       }

--- a/inst/htmlwidgets/igvShiny.js
+++ b/inst/htmlwidgets/igvShiny.js
@@ -549,6 +549,8 @@ Shiny.addCustomMessageHandler("loadBedGraphTrackFromURL",
       console.log("--- loading bedGraphTrackFromURL");
       console.log(config)
       config = mergeExtraParameters(config, message);
+      if(autoscaleGroup >= 0)
+          config['autoscaleGroup'] = autoscaleGroup;
       igvBrowser.loadTrack(config);
       }
 


### PR DESCRIPTION
## Summary
- `loadBedGraphTrackFromURL` in `inst/htmlwidgets/igvShiny.js` read `autoscaleGroup` from the message but never added it to the track `config`, so tracks loaded via this handler never shared an autoscale group even when one was requested.
- The sibling handler `loadBedGraphTrack` already does this correctly (`if(autoscaleGroup >= 0) config['autoscaleGroup'] = autoscaleGroup;`), applied after `mergeExtraParameters` and before `loadTrack`. This PR adds the same two lines to `loadBedGraphTrackFromURL` for consistency.

Fixes #105.

## Test plan
- [x] `devtools::load_all()` + `inst/demos/groupAutoScale.R` (adds a bedGraph track from URL with `autoscaleGroup=1`)
- [x] Confirmed in browser devtools console that the `config` object passed to `igvBrowser.loadTrack()` now includes `autoscaleGroup: 1`, which it did not before the fix
- [x] `devtools::check()`: 0 errors, 0 warnings, 1 pre-existing NOTE (unrelated, non-standard top-level files)