### PR TITLE
chore: credit past contributors in DESCRIPTION, bump to 1.9.6

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 ^AGENTS\.md$
 ^Containerfile$
 ^\.serena$
+^CLAUDE\.md$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@
 ^Meta$
 ^AGENTS\.md$
 ^Containerfile$
+^\.serena$

--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,7 @@ vignettes/*.pdf
 /Meta/
 # exploratory / dev notes, mirrored to GDrive instead of git
 /explore
+# serena MCP language-server cache/config (local dev tooling)
+/.serena
 # Containerfile build log
 build_log.txt

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,15 +1,25 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.5
-Date: 2026-07-06
+Version: 1.9.6
+Date: 2026-07-17
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 
     email = "paul.thurmond.shannon@gmail.com"),
     person("Arkadiusz", "Gladki", role=c("aut", "cre"), 
     email="gladki.arkadiusz@gmail.com", comment = c(ORCID = "0000-0002-7059-6378")),
-    person("Karolina","Scigocka", role = c("aut"), 
-    email = "scigocka.karolina@gmail.com")
+    person("Karolina","Scigocka", role = c("aut"),
+    email = "scigocka.karolina@gmail.com"),
+    person("Carolina", "Heimann", role = c("ctb"),
+    email = "carolina.heimann@gmail.com"),
+    person("Steffen", "Klasberg", role = c("ctb"),
+    email = "klasberg@dkms-lab.de"),
+    person("Vincent", "Carey", role = c("ctb"),
+    email = "stvjc@channing.harvard.edu"),
+    person("Parv", "Sachdeva", role = c("ctb"),
+    email = "parv.sachdeva@sonomabio.com"),
+    person("Mateusz", "Gladki", role = c("ctb"),
+    email = "gladkiimateusz@gmail.com")
     )
 Description: This package is a wrapper of Integrative Genomics Viewer (IGV).
     It comprises an htmlwidget version of IGV. It can be used as a module 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## igvShiny 1.9.6
+* docs: credit past contributors in `DESCRIPTION` — Carolina Heimann, Steffen
+  Klasberg, Vincent Carey, Parv Sachdeva and Mateusz Gladki are now listed as
+  `ctb`
+
 ## igvShiny 1.9.5
 * fix: pass `tracks` startup option through to igv.js (#36, thanks @M4teuszzGl4dki)
 


### PR DESCRIPTION
Several people with merged code contributions were missing from `Authors@R`. This adds them as `ctb`, based on going through the commit history:

| Contributor | Contribution |
|---|---|
| Carolina Heimann | GWAS demo app, Shiny module support (16 commits) |
| Steffen Klasberg | custom local/remote genome support — still live in `genomeSpecificOptions()` |
| Vincent Carey | load time, removing `R CMD check` warnings |
| Parv Sachdeva | #88 |
| Mateusz Gladki | #105, #36 |

Bioconductor core team commits (A/J Wokaty) are `bump x.y.z version` only, so they are deliberately left out, as is a single typo fix in DESCRIPTION.

Verified that `Authors@R` parses (8 people, roles intact) and `tools:::.check_package_description()` reports nothing. The author list is not duplicated anywhere else, so DESCRIPTION stays the single source of truth.

Also ignores serena's local tooling directory. It goes in **both** `.gitignore` and `.Rbuildignore` — `R CMD build` packs what is on disk regardless of git, so gitignoring alone would still let `.serena/` into the tarball as a non-standard top-level file.

Version 1.9.5 → 1.9.6 with a NEWS entry, per the convention in this repo.