### PR TITLE
Restore mm10 and danRer11 stock genomes (partial fix for #107)

### DIFF
--- a/inst/htmlwidgets/igvShiny.js
+++ b/inst/htmlwidgets/igvShiny.js
@@ -164,6 +164,27 @@ function genomeSpecificOptions(genomeName, stockGenome, dataMode, initialLocus, 
          showRuler: true,
          genome: genomeName
          };
+       // Work around broken upstream genomes.json fasta index URLs (issue #107).
+       // For these stock genomes igv.js resolves the sequence from the live
+       // https://igv.org/genomes/genomes.json, whose fasta indexURLs currently
+       // 404, so the genome never displays. Supply an explicit, verified
+       // reference with working fastaURL/indexURL instead of the bare id.
+       // Temporary: to be removed once igv.js is upgraded to 3.x (issue #107 / C).
+       // rn6 is intentionally not covered here: it has no working plain fasta
+       // index available upstream, and igv.js 2.13.1 does not support twoBitURL;
+       // it will be fixed by the igv.js 3.x upgrade.
+       var brokenStockGenomeReference = {
+          mm10: {id: "mm10",
+                 fastaURL: "https://igv.org/genomes/data/mm10/mm10.fa",
+                 indexURL: "https://igv.org/genomes/data/mm10/mm10.fa.fai"},
+          danRer11: {id: "danRer11",
+                     fastaURL: "https://s3.amazonaws.com/igv.org.genomes/danRer11/danRer11.fa",
+                     indexURL: "https://s3.amazonaws.com/igv.org.genomes/danRer11/danRer11.fa.fai"}
+          };
+       if (brokenStockGenomeReference.hasOwnProperty(genomeName)) {
+          delete igvOptions.genome;
+          igvOptions.reference = brokenStockGenomeReference[genomeName];
+          }
        if (tracks && tracks.length > 0) {
           igvOptions.tracks = tracks;
        }

--- a/inst/htmlwidgets/igvShiny.js
+++ b/inst/htmlwidgets/igvShiny.js
@@ -170,16 +170,37 @@ function genomeSpecificOptions(genomeName, stockGenome, dataMode, initialLocus, 
        // 404, so the genome never displays. Supply an explicit, verified
        // reference with working fastaURL/indexURL instead of the bare id.
        // Temporary: to be removed once igv.js is upgraded to 3.x (issue #107 / C).
+       //
+       // The reference below must repeat everything the genomes.json entry
+       // carries, not just the sequence URLs: a config with both id and
+       // fastaURL is returned as-is by expandReference(), so igv.js never
+       // looks the id up in KNOWN_GENOMES and anything omitted here is simply
+       // lost (loadGenome falls back to `genomeConfig.tracks || []`).
+       //
        // rn6 is intentionally not covered here: it has no working plain fasta
        // index available upstream, and igv.js 2.13.1 does not support twoBitURL;
        // it will be fixed by the igv.js 3.x upgrade.
        var brokenStockGenomeReference = {
           mm10: {id: "mm10",
                  fastaURL: "https://igv.org/genomes/data/mm10/mm10.fa",
-                 indexURL: "https://igv.org/genomes/data/mm10/mm10.fa.fai"},
+                 indexURL: "https://igv.org/genomes/data/mm10/mm10.fa.fai",
+                 cytobandURL: "https://hgdownload.soe.ucsc.edu/goldenPath/mm10/database/cytoBandIdeo.txt.gz",
+                 chromosomeOrder: "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chrX,chrY",
+                 tracks: [{name: "Refseq Curated",
+                           format: "refgene",
+                           url: "https://hgdownload.soe.ucsc.edu/goldenPath/mm10/database/ncbiRefSeqCurated.txt.gz",
+                           indexed: false,
+                           order: 1000000}]},
           danRer11: {id: "danRer11",
                      fastaURL: "https://s3.amazonaws.com/igv.org.genomes/danRer11/danRer11.fa",
-                     indexURL: "https://s3.amazonaws.com/igv.org.genomes/danRer11/danRer11.fa.fai"}
+                     indexURL: "https://s3.amazonaws.com/igv.org.genomes/danRer11/danRer11.fa.fai",
+                     cytobandURL: "https://hgdownload.soe.ucsc.edu/goldenPath/danRer11/database/cytoBandIdeo.txt.gz",
+                     aliasURL: "https://hgdownload.soe.ucsc.edu/goldenPath/danRer11/bigZips/danRer11.chromAlias.txt",
+                     chromosomeOrder: "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chr23,chr24,chr25",
+                     tracks: [{name: "Refseq Curated",
+                               format: "refgene",
+                               url: "https://hgdownload.soe.ucsc.edu/goldenPath/danRer11/database/ncbiRefSeqCurated.txt.gz",
+                               order: 1000000}]}
           };
        if (brokenStockGenomeReference.hasOwnProperty(genomeName)) {
           delete igvOptions.genome;


### PR DESCRIPTION
Partial fix for #107. Restores mm10 and danRer11; rn6 is not covered (see below), so this does not close the issue.

## Why the genomes fail

Not an igvShiny bug. For a stock genome we pass a bare `genome: <id>`, and igv.js 2.13.1 resolves the definition from the live `https://igv.org/genomes/genomes.json`. That file is currently byte-identical to `genomes/legacy/genomes.json` in `igvteam/igv-data`, and three of its entries point at fasta indexes that no longer resolve:

| genome | `indexURL` in the served genomes.json | status |
|---|---|---|
| mm10 | `https://igv.org/genomes/data/mm10.fa.fai` (missing `/mm10/`) | 404 |
| danRer11 | `https://igv.org/genomes/data/danRer11/danRer11.fa.fai` | 404 (whole directory) |
| rn6 | `https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/rn6/rn6.fa.fai` | 403 |

hg38 is unaffected, which matches the report. In the browser the failing request surfaces as `net::ERR_FAILED` rather than a readable 404, because the broken paths return no CORS headers.

This is being reported upstream separately; the patch here is a temporary local workaround, to be reverted once igv.js is upgraded to 3.x.

## What this does

In the `stockGenome` branch of `genomeSpecificOptions()`, mm10 and danRer11 get an explicit `reference` with working sequence URLs instead of the bare id. mm10 uses the corrected `igv.org` path; danRer11 uses `s3.amazonaws.com/igv.org.genomes/`, which is where igv.js's own fallback genome list (`BACKUP_GENOMES_URL`, igv-2.13.1.js:25158) already points danRer11. All other genomes are untouched.

The reference repeats the rest of the upstream entry — `cytobandURL`, `chromosomeOrder`, the Refseq Curated track, and `aliasURL` for danRer11. This part is not optional: `expandReference()` (igv-2.13.1.js:25232) returns a config carrying both `id` and `fastaURL` as-is, so the `KNOWN_GENOMES` lookup never happens and anything omitted is silently lost (`loadGenome()` falls back to `genomeConfig.tracks || []`). An earlier revision of this branch omitted them and produced a genome that loaded with the sequence only — no gene track, and an ideogram track with no cytoband data.

## rn6 is deliberately excluded

rn6 has no working plain fasta index anywhere: the original S3 bucket 403s, the backup bucket 404s, and UCSC offers only `.fa.gz` with no `.fai`. UCSC's 2bit for rn6 is alive, but igv.js 2.13.1 has no twoBit support at all (`grep twoBit` on the bundled file returns nothing). Upstream has also moved rn6 to twoBit-only in the newer genome catalogue — its entry there has no `fastaURL` at all. So rn6 is only fixable by the igv.js 3.x upgrade, and is left as a documented limitation in the code comment.

## Verification

- Object shape checked in Node against the live genomes.json entries: `reference` set for mm10/danRer11 with cytoband/chromosomeOrder/track matching upstream, hg38 and rn6 untouched, and the `tracks` passthrough from #36 still behaving (empty list adds no key, per ff16cb6).
- Headless browser (chromote/CDP) for both genomes: the `.fai` now loads (200, previously `ERR_FAILED`), and `cytoBandIdeo`/`ncbiRefSeqCurated` both return 200 with no failed requests. igv.js reports `Refseq Curated` among its tracks and resolves cytobands; before this fix the track was absent and `getCytobands()` returned nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed genome loading for the mm10 and danRer11 stock genomes.
  * These genomes now use verified sequence and index sources, improving reliability when displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->