### PR TITLE
Modernize Posit Connect demo UI with bslib (Bootstrap 5)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.6
-Date: 2026-07-17
+Version: 1.9.7
+Date: 2026-07-23
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 
     email = "paul.thurmond.shannon@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+## igvShiny 1.9.7
+* demo: add a public, clickable demo app deployed on Posit Connect Cloud, plus
+  the repository's first `README` (#117, #118)
+* demo: modern `bslib` (Bootstrap 5) UI for the Connect demo — grouped controls,
+  themed layout, IGV viewer in a full-screen-able card (#119)
+
 ## igvShiny 1.9.6
 * docs: credit past contributors in `DESCRIPTION` — Carolina Heimann, Steffen
   Klasberg, Vincent Carey, Parv Sachdeva and Mateusz Gladki are now listed as

--- a/demo/posit-connect/app.R
+++ b/demo/posit-connect/app.R
@@ -6,11 +6,13 @@
 #   - BAM-from-URL / CRAM-from-URL kept: igv.js fetches these client-side,
 #     so they demo alignment tracks with zero server-side dependency.
 #
-# Everything the server does at runtime is tiny: a 74K gwas.RData at startup
-# plus small in-memory data.frames on button clicks. igv.js does the heavy
-# rendering in the browser.
+# UI uses bslib (Bootstrap 5): a page_sidebar layout with the IGV viewer in a
+# full-screen-able card and the track/navigation controls grouped into an
+# accordion. The server logic is unchanged from the classic demo — same input
+# ids — only the UI layer is restyled.
 
 library(shiny)
+library(bslib)
 library(igvShiny)
 library(htmlwidgets)
 
@@ -49,37 +51,91 @@ tbl.wig <- data.frame(chr = rep("1", wig.size),
                       value = values.100,
                       stringsAsFactors = FALSE)
 #----------------------------------------------------------------------------------------------------
-ui <- shinyUI(fluidPage(
+# a full-width action button with a leading icon, styled consistently
+demoButton <- function(id, label, icon_name, class = "btn-outline-primary") {
+  actionButton(id, label, icon = icon(icon_name),
+               class = paste("w-100 mb-2 text-start", class))
+}
 
-  sidebarLayout(
-    sidebarPanel(
-      actionButton("searchButton", "Search"),
-      textInput("roi", label = ""),
-      h5("One simple data.frame, three igv formats:"),
-      actionButton("addBedTrackButton", "Add as Bed"),
-      actionButton("addBedGraphTrackButton", "Add as BedGraph"),
-      actionButton("addBedGraphWithAltColorTrackButton", "Add as BedGraph (with AltColor)"),
-      actionButton("addBedGraphTrackFromURLButton", "Add BedGraph from URL"),
-      br(),
-      actionButton("addBed9TrackButton", "bed9 track"),
-      actionButton("addGwasTrackButton", "Add GWAS Track"),
-      actionButton("addBamViaHttpButton", "BAM from URL"),
-      actionButton("addCramViaHttpButton", "CRAM from URL"),
-      actionButton("removeUserTracksButton", "Remove User Tracks"),
-      actionButton("getChromLocButton", "Get Region"),
-      actionButton("clearChromLocButton", "Clear Region"),
-      div(style = "background-color: white; width: 200px; height:30px; padding-left: 5px;
-                   margin-top: 10px; border: 1px solid blue;",
-          htmlOutput("chromLocDisplay")),
-      hr(),
-      width = 2
+theme <- bs_theme(
+  version = 5,
+  primary = "#2c6faa",
+  base_font = font_google("Inter", local = FALSE),
+  heading_font = font_google("Inter", local = FALSE)
+)
+
+ui <- page_sidebar(
+  title = "igvShiny — interactive genome browser",
+  theme = theme,
+  fillable = TRUE,
+
+  sidebar = sidebar(
+    width = 300,
+    title = "Controls",
+
+    # keep the search box always visible above the accordion
+    div(
+      class = "mb-3",
+      textInput("roi", label = "Search locus / gene", placeholder = "e.g. MEF2C or chr1:7,426,231-7,453,241"),
+      actionButton("searchButton", "Search", icon = icon("magnifying-glass"),
+                   class = "btn-primary w-100")
     ),
-    mainPanel(
-      igvShinyOutput('igvShiny_0'),
-      width = 10
+
+    accordion(
+      open = c("Sample-data tracks", "Tracks from URL"),
+
+      accordion_panel(
+        "Sample-data tracks", icon = icon("table"),
+        demoButton("addBedTrackButton", "BED", "align-left"),
+        demoButton("addBedGraphTrackButton", "BedGraph", "chart-area"),
+        demoButton("addBedGraphWithAltColorTrackButton", "BedGraph (AltColor)", "palette"),
+        demoButton("addBed9TrackButton", "bed9", "grip-lines"),
+        demoButton("addGwasTrackButton", "GWAS", "chart-column")
+      ),
+
+      accordion_panel(
+        "Tracks from URL", icon = icon("cloud-arrow-down"),
+        demoButton("addBedGraphTrackFromURLButton", "BedGraph (URL)", "chart-area", "btn-outline-secondary"),
+        demoButton("addBamViaHttpButton", "BAM (URL)", "dna", "btn-outline-secondary"),
+        demoButton("addCramViaHttpButton", "CRAM (URL)", "dna", "btn-outline-secondary")
+      ),
+
+      accordion_panel(
+        "Region tools", icon = icon("location-crosshairs"),
+        demoButton("getChromLocButton", "Get region", "crosshairs", "btn-outline-dark"),
+        demoButton("clearChromLocButton", "Clear region", "eraser", "btn-outline-dark"),
+        demoButton("removeUserTracksButton", "Remove user tracks", "trash-can", "btn-outline-danger"),
+        div(class = "small text-muted mt-1 mb-1", "Current region:"),
+        div(class = "border rounded p-2 small bg-body-tertiary font-monospace",
+            htmlOutput("chromLocDisplay"))
+      )
+    ),
+
+    # footer: quick links back to the project
+    tags$div(
+      class = "mt-auto pt-2 small",
+      tags$a(href = "https://github.com/gladkia/igvShiny", target = "_blank",
+             class = "link-secondary text-decoration-none me-3",
+             icon("github"), " GitHub"),
+      tags$a(href = "https://gladkia.github.io/igvShiny/", target = "_blank",
+             class = "link-secondary text-decoration-none",
+             icon("book"), " Docs")
     )
-  ) # sidebarLayout
-))
+  ),
+
+  card(
+    full_screen = TRUE,
+    card_header(
+      class = "d-flex align-items-center gap-2",
+      icon("dna"), "Genome viewer",
+      tags$span(class = "badge text-bg-light ms-auto", "hg38")
+    ),
+    card_body(
+      class = "p-0",
+      igvShinyOutput('igvShiny_0', height = "100%")
+    )
+  )
+)
 #----------------------------------------------------------------------------------------------------
 server <- function(input, output, session) {
 

--- a/demo/posit-connect/manifest.json
+++ b/demo/posit-connect/manifest.json
@@ -2045,7 +2045,7 @@
   },
   "files": {
     "app.R": {
-      "checksum": "159d5916e1e948cf078f1581cd365996"
+      "checksum": "3f97231d41157e7ede7ef2204a25745f"
     },
     "README.md": {
       "checksum": "d53ea685445af776d65888e4828ab732"


### PR DESCRIPTION
Closes #119

## What

Rebuilds the **UI layer** of `demo/posit-connect/app.R` with [`bslib`](https://rstudio.github.io/bslib/) (Bootstrap 5). Server logic and every input id are unchanged, so behaviour is identical — only the look changes.

- `page_sidebar` layout, clean theme (primary `#2c6faa`, Inter font).
- IGV viewer in a full-screen-able **card** that fills the height.
- Controls grouped into an **accordion**: *Sample-data tracks* / *Tracks from URL* / *Region tools*, full-width buttons with icons.
- Search box with placeholder above the accordion; monospace current-region readout; GitHub / Docs links in the sidebar footer.

## Why

The demo doubles as a shop window for the package; the old raw `sidebarLayout` + ungrouped buttons looked dated (BS3). This is a big visual upgrade for a UI-only change.

## Notes

- `manifest.json` regenerated — `bslib` added to the pinned set (already a transitive Shiny dep, so still 72 pkgs); `igvShiny` still pinned to GitHub master (1.9.6); no `Rsamtools`/`GenomicAlignments`.
- Verified: UI force-renders without errors (bslib BS5, accordion, viewer output), app runs locally.
- On merge, Connect Cloud (source = `master`) auto-redeploys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refreshed the Shiny demo with a modern sidebar layout and themed controls.
  * Grouped settings into expandable sections for easier navigation.
  * Added icon-enhanced demo buttons and a full-screen viewer option.
  * Added footer links to project resources.

* **Bug Fixes**
  * Updated deployment metadata to reflect the latest demo changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->