### PR TITLE
M1: clear two BiocCheck NOTEs (vignette chunk labels, funder role)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.7
+Version: 1.9.8
 Date: 2026-07-23
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 
@@ -19,7 +19,8 @@ Authors@R: c(
     person("Parv", "Sachdeva", role = c("ctb"),
     email = "parv.sachdeva@sonomabio.com"),
     person("Mateusz", "Gladki", role = c("ctb"),
-    email = "gladkiimateusz@gmail.com")
+    email = "gladkiimateusz@gmail.com"),
+    person("R Consortium", role = "fnd")
     )
 Description: This package is a wrapper of Integrative Genomics Viewer (IGV).
     It comprises an htmlwidget version of IGV. It can be used as a module 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 ## igvShiny 1.9.8
-* docs: add labels to all vignette code chunks (BiocCheck)
-* desc: credit R Consortium with the `fnd` (funder) role in `Authors@R` — the
-  ISC grant funding this work (BiocCheck)
+* Add labels to all vignette code chunks (BiocCheck)
+* Add the R Consortium `fnd` (funder) role to `Authors@R` — the ISC grant
+  funding this work (BiocCheck)
 
 ## igvShiny 1.9.7
 * demo: add a public, clickable demo app deployed on Posit Connect Cloud, plus

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## igvShiny 1.9.8
+* docs: add labels to all vignette code chunks (BiocCheck)
+* desc: credit R Consortium with the `fnd` (funder) role in `Authors@R` — the
+  ISC grant funding this work (BiocCheck)
+
 ## igvShiny 1.9.7
 * demo: add a public, clickable demo app deployed on Posit Connect Cloud, plus
   the repository's first `README` (#117, #118)

--- a/vignettes/igvShiny.Rmd
+++ b/vignettes/igvShiny.Rmd
@@ -12,7 +12,7 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r, include = FALSE}
+```{r setup, include = FALSE}
 knitr::opts_chunk$set(
     collapse = TRUE,
     comment = "#>"
@@ -27,7 +27,7 @@ It can be used as a module in Shiny apps.
 
 # Installation
 
-```{r,eval=FALSE}
+```{r install, eval=FALSE}
 if (!requireNamespace("BiocManager", quietly = TRUE))
     install.packages("BiocManager")
 
@@ -36,7 +36,7 @@ BiocManager::install("igvShiny")
 
 # Loading the package
 
-```{r,include=TRUE,results="hide",message=FALSE,warning=FALSE}
+```{r load-package, include=TRUE, results="hide", message=FALSE, warning=FALSE}
 library(igvShiny)
 ```
 
@@ -50,7 +50,7 @@ Running the minimal Shiny app with igvShiny is as simple as:
 
 The he minimal Shiny app make look like: 
 
-```{r,eval=FALSE}
+```{r minimal-app, eval=FALSE}
 library(igvShiny)
 options <- parseAndValidateGenomeSpec(genomeName="hg38",  initialLocus="NDUFS2")
 if (interactive()) {
@@ -74,18 +74,18 @@ One can select any stock genome easily by running `parseAndValidateGenomeSpec`
 with single `genomeName` value properly assigned.
 For example to use the most popular mouse genome one need to run:
 
-```{r,echo=TRUE}
+```{r stock-genome-spec, echo=TRUE}
 igvShiny::parseAndValidateGenomeSpec("mm10")
 ```
 
 The list of available stock genomes in igvShiny can be found with:
-```{r,echo=TRUE}
+```{r list-stock-genomes, echo=TRUE}
 igvShiny::get_css_genomes()
 ```
 
 See also demo app for stock genomes when one can select genome of interest 
 and familiarize with the basic functionalities provided via igvShiny:
-```{r,echo=TRUE}
+```{r stock-genomes-demo, echo=TRUE}
 library(igvShiny)
 demo_app_file <- system.file(package= "igvShiny", "demos", "stockGenomesDemo.R")
     if (interactive()) {
@@ -99,7 +99,7 @@ In such cases  one has to provide data for:
 The files can provided as local paths (`dataMode` = `localFiles` or via URLs
 (`dataMode = http`). See below the examples for both cases.
 
-```{r,echo=TRUE}
+```{r custom-genome-spec, echo=TRUE}
 library(igvShiny)
 
 # defining custom genome with data provided via URLs
@@ -138,11 +138,11 @@ genomeOptions2
 ```
 
 See also demo apps for custom genomes with data provided via URLs:
-```{r,echo=TRUE}
+```{r custom-genome-http-demo, echo=TRUE}
 library(igvShiny)
 demo_app_file <- system.file(
-    package = "igvShiny", 
-    "demos", 
+    package = "igvShiny",
+    "demos",
     "igvShinyDemo-customGenome-http.R"
     )
 if (interactive()) {
@@ -150,7 +150,7 @@ if (interactive()) {
     }
 ```
 as well as data provided via local files:
-```{r,echo=TRUE}
+```{r custom-genome-local-demo, echo=TRUE}
 library(igvShiny)
 demo_app_file <-
     system.file(
@@ -186,7 +186,7 @@ added during the session by the user)
 
 See also demo app to familiarize with the basic functionalities 
 provided by igvShiny:
-```{r,echo=TRUE}
+```{r main-demo, echo=TRUE}
 library(igvShiny)
 demo_app_file <- system.file(package= "igvShiny", "demos", "igvShinyDemo.R")
 if (interactive()) {
@@ -196,6 +196,6 @@ if (interactive()) {
 
 # Session Info
 
-```{r}
+```{r session-info}
 sessionInfo()
 ```


### PR DESCRIPTION
Part of **M1 (Bug fixes + BiocCheck compliance)**.

Two zero-risk BiocCheck NOTE removals:

- **`checkChunkLabels`** — added labels to all 12 code chunks in `vignettes/igvShiny.Rmd` (`setup`, `install`, `load-package`, `minimal-app`, `stock-genome-spec`, …).
- **`checkFndPerson`** — added `person("R Consortium", role = "fnd")` to `Authors@R`, crediting the ISC grant that funds this work.

Verified with `BiocCheck`: **NOTES drop from 5 → 3** on Bioc devel.

### What remains for a BiocCheck-clean M1 (not in this PR)

| Item | Notes |
|------|-------|
| `checkFormatting` ×2 — line length (25 lines >80) + indentation (485 lines not multiples of 4) | best done together in a dedicated `styler` pass; large diff, review carefully |
| `checkFunctionLengths` — 7 functions >50 lines | refactor pass |
| `checkVersionNumber` WARNING — "y should be even in release" | **CI-context artifact**: `check-bioc.yml` tests against `RELEASE_3_22` while the package carries a devel version (odd `y`). Does not appear on the Bioc devel dashboard. Optional fix: point the CI matrix at Bioc devel. |

Bump to 1.9.8 + NEWS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the vignette with clearly labeled code examples and sections, making it easier to navigate and reuse.
  * Improved organization of setup, installation, genome examples, demonstrations, and session information.
* **Release Information**
  * Added release notes for version 1.9.8, including documentation improvements and updated project acknowledgments.
  * Updated package metadata and credited R Consortium funding support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->