### PR TITLE
style: clear the BiocCheck line-length NOTE (M1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ vignettes/*.pdf
 /.serena
 # Containerfile build log
 build_log.txt
+
+# BiocCheck artifacts
+*.BiocCheck/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.9
+Version: 1.9.10
 Date: 2026-07-23
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,7 @@
 ## igvShiny 1.9.10
-* Wrap the 25 over-long source lines in `R/igvShiny.R` at 80 characters,
-  clearing the BiocCheck line-length NOTE
-* Build warning messages outside the condition signals so `paste()` is not
-  called inside `warning()` (BiocCheck coding-practice NOTE); the emitted
-  message text is unchanged
-* Ignore local `*.BiocCheck/` output folders in git
+* Wrap the 25 over-long lines in `R/igvShiny.R` at 80 characters (BiocCheck)
+* Move `paste()` out of `warning()` calls, keeping the message text unchanged
+* Exclude local `*.BiocCheck/` output folders from git
 
 ## igvShiny 1.9.9
 * Bump the bundled igv.js from 2.13.1 to 3.8.4 (minified) and update the

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+## igvShiny 1.9.10
+* Wrap the 25 over-long source lines in `R/igvShiny.R` at 80 characters,
+  clearing the BiocCheck line-length NOTE
+* Build warning messages outside the condition signals so `paste()` is not
+  called inside `warning()` (BiocCheck coding-practice NOTE); the emitted
+  message text is unchanged
+* Ignore local `*.BiocCheck/` output folders in git
+
 ## igvShiny 1.9.9
 * Bump the bundled igv.js from 2.13.1 to 3.8.4 (minified) and update the
   `locuschange` handler for the 3.x event payload — it now reads the locus from

--- a/R/igvShiny.R
+++ b/R/igvShiny.R
@@ -9,13 +9,14 @@
 # This allowlist prevents arbitrary code injection and invalid options.
 # Sourced from igv.js documentation.
 .validIgvTrackOptions <- c(
-  "name", "type", "format", "url", "indexURL", "indexed", "order", "displayMode",
-  "color", "altColor", "negColor", "posColor", "borderColor", "trait",
-  "height", "autoHeight", "minHeight", "maxHeight", "removable",
+  "name", "type", "format", "url", "indexURL", "indexed", "order",
+  "displayMode", "color", "altColor", "negColor", "posColor", "borderColor",
+  "trait", "height", "autoHeight", "minHeight", "maxHeight", "removable",
   "visibilityWindow", "searchable", "autoScale", "autoscale", "autoScaleGroup",
   "autoscaleGroup", "min", "max", "logScale", "graphType", "barChart",
-  "flipAxis", "stroke", "noStroke", "fill", "noFill", "featureHeight", "showLabels",
-  "font", "fontSize", "fontStyle", "fontWeight", "colorTable", "colorByAttribute",
+  "flipAxis", "stroke", "noStroke", "fill", "noFill", "featureHeight",
+  "showLabels", "font", "fontSize", "fontStyle", "fontWeight", "colorTable",
+  "colorByAttribute",
   "showAllBases", "samplingWindowSize", "samplingDepth", "maxRows",
   "hideEmptyTracks", "oauthToken", "headers", "viewAsPairs", "pairsSupported",
   "maxPanelHeight", "separateBam", "wholeGenomeView", "roi", "queryable"
@@ -26,31 +27,37 @@
 #' Sanitize and merge track configuration options
 #' @param baseOptions A list of default options set by the R function.
 #' @param userOptions A list of options provided by the user via trackConfig.
-#' @return A merged and sanitized list of options ready to be sent to JavaScript.
+#' @return A merged and sanitized list of options ready to be sent to
+#' JavaScript.
 #' @keywords igvShiny
 .sanitizeAndMergeOptions <- function(baseOptions, userOptions) {
   if (is.null(userOptions) || length(userOptions) == 0) {
     return(baseOptions)
   }
 
-  if (!is.list(userOptions) || is.null(names(userOptions)) || any(names(userOptions) == "")) {
+  if (!is.list(userOptions) || is.null(names(userOptions)) ||
+      any(names(userOptions) == "")) {
     warning("trackConfig must be a named list. Ignoring.")
     return(baseOptions)
   }
 
-  # Identify and warn about conflicting keys that would override explicit function arguments
+  # Identify and warn about conflicting keys that would override explicit
+  # function arguments
   conflictingKeys <- intersect(names(baseOptions), names(userOptions))
   if (length(conflictingKeys) > 0) {
-    warning(sprintf("User-provided trackConfig options conflict with function arguments and will be ignored: %s",
-                    toString(conflictingKeys)))
-    userOptions[conflictingKeys] <- NULL # Prioritize base options for security and clarity
+    fmt <- paste("User-provided trackConfig options conflict with function",
+                 "arguments and will be ignored: %s")
+    warning(sprintf(fmt, toString(conflictingKeys)))
+    # Prioritize base options for security and clarity
+    userOptions[conflictingKeys] <- NULL
   }
 
   # Filter user options against the allowlist of valid igv.js parameters
   invalidKeys <- setdiff(names(userOptions), .validIgvTrackOptions)
   if (length(invalidKeys) > 0) {
-    warning(sprintf("Ignoring invalid or unsupported track options in trackConfig: %s",
-                    toString(invalidKeys)))
+    fmt <- paste("Ignoring invalid or unsupported track options in",
+                 "trackConfig: %s")
+    warning(sprintf(fmt, toString(invalidKeys)))
     userOptions[invalidKeys] <- NULL
   }
 
@@ -69,18 +76,24 @@
   }
 
   Filter(Negate(is.null), lapply(tracks, function(track) {
-    if (!is.list(track) || is.null(names(track)) || any(is.na(names(track))) || any(names(track) == "")) {
-      warning("Ignoring invalid entry in 'tracks': each entry must be a named list.")
+    if (!is.list(track) || is.null(names(track)) || any(is.na(names(track))) ||
+        any(names(track) == "")) {
+      msg <- paste("Ignoring invalid entry in 'tracks': each entry must be",
+                   "a named list.")
+      warning(msg)
       return(NULL)
     }
     invalidKeys <- setdiff(names(track), .validIgvTrackOptions)
     if (length(invalidKeys) > 0) {
-      warning(sprintf("Ignoring invalid or unsupported track options in 'tracks': %s",
-                      toString(invalidKeys)))
+      fmt <- paste("Ignoring invalid or unsupported track options in",
+                   "'tracks': %s")
+      warning(sprintf(fmt, toString(invalidKeys)))
       track[invalidKeys] <- NULL
     }
     if (is.null(track[["url"]])) {
-      warning("Dropping entry in 'tracks' with no valid 'url' after removing unsupported options.")
+      msg <- paste("Dropping entry in 'tracks' with no valid 'url' after",
+                   "removing unsupported options.")
+      warning(msg)
       return(NULL)
     }
     track
@@ -423,7 +436,8 @@ removeUserAddedTracks <- function(session, id) {
 #' @param trackHeight an integer, 50 (pixels) by default
 #' @param deleteTracksOfSameName logical, default TRUE
 #' @param quiet logical, default TRUE, controls verbosity
-#' @param trackConfig a named list of additional igv.js track configuration options.
+#' @param trackConfig a named list of additional igv.js track configuration
+#' options.
 #'
 #' @examples
 #' library(igvShiny)
@@ -536,7 +550,8 @@ loadBedTrack <-
 #' @param quiet logical, default TRUE, controls verbosity
 #' @param autoscaleGroup numeric(1) defaults to -1
 #' @param deleteTracksOfSameName logical(1) defaults to TRUE
-#' @param trackConfig a named list of additional igv.js track configuration options.
+#' @param trackConfig a named list of additional igv.js track configuration
+#' options.
 #'
 #' @examples
 #' library(igvShiny)
@@ -635,7 +650,8 @@ loadBedGraphTrackFromURL <-
 #' @param max numeric, consulted when autoscale is FALSE
 #' @param deleteTracksOfSameName logical, default TRUE
 #' @param quiet logical, default TRUE, controls verbosity
-#' @param trackConfig a named list of additional igv.js track configuration options.
+#' @param trackConfig a named list of additional igv.js track configuration
+#' options.
 #'
 #' @examples
 #' library(igvShiny)
@@ -743,7 +759,8 @@ loadBedGraphTrack <-
 #' @param trackName character string
 #' @param tbl data.frame, with at least "chrom" "start" "end" "score" columns
 #' @param deleteTracksOfSameName logical, default TRUE
-#' @param trackConfig a named list of additional igv.js track configuration options.
+#' @param trackConfig a named list of additional igv.js track configuration
+#' options.
 #'
 #' @examples
 #' library(igvShiny)
@@ -804,7 +821,8 @@ loadSegTrack <-
 #' @param trackName character string
 #' @param vcfData VariantAnnotation object
 #' @param deleteTracksOfSameName logical, default TRUE
-#' @param trackConfig a named list of additional igv.js track configuration options.
+#' @param trackConfig a named list of additional igv.js track configuration
+#' options.
 #'
 #' @examples
 #' library(igvShiny)
@@ -837,7 +855,8 @@ loadVcfTrack <- function(session,
   state[["userAddedTracks"]] <-
     unique(c(state[["userAddedTracks"]], trackName))
   temp.file <- tempfile(tmpdir = get_tracks_dir(), fileext = ".vcf")
-  lmsg <- sprintf("igvShiny::loadVcfTrack, about to write to file '%s'", temp.file)
+  lmsg <- sprintf("igvShiny::loadVcfTrack, about to write to file '%s'",
+                  temp.file)
   flog.debug(lmsg)
   VariantAnnotation::writeVcf(vcfData, temp.file)
   lmsg2 <- sprintf("igvShiny::loadVcfTrack, file.exists(%s)? %s",
@@ -875,7 +894,8 @@ loadVcfTrack <- function(session,
 #' @param ymax numeric defaults to 35
 #' @param tbl.gwas data.frame, with at least "chrom" "start" "end" columns
 #' @param deleteTracksOfSameName logical, default TRUE
-#' @param trackConfig a named list of additional igv.js track configuration options.
+#' @param trackConfig a named list of additional igv.js track configuration
+#' options.
 #'
 #' @examples
 #' library(igvShiny)
@@ -960,7 +980,8 @@ loadGwasTrack <- function(session,
 #' @param displayMode character string, possible values are "EXPANDED"(default),
 #' "SQUISHED" or "COLLAPSED"
 #' @param showAllBases logical, show all bases in the alignment, default FALSE
-#' @param trackConfig a named list of additional igv.js track configuration options.
+#' @param trackConfig a named list of additional igv.js track configuration
+#' options.
 #'
 #' @examples
 #' library(igvShiny)
@@ -1022,7 +1043,8 @@ loadBamTrackFromURL <-
 #' @param deleteTracksOfSameName logical, default TRUE
 #' @param displayMode character string, possible values are "EXPANDED"(default),
 #' "SQUISHED" or "COLLAPSED"
-#' @param trackConfig a named list of additional igv.js track configuration options.
+#' @param trackConfig a named list of additional igv.js track configuration
+#' options.
 #'
 #' @examples
 #' library(igvShiny)
@@ -1094,7 +1116,8 @@ loadBamTrackFromLocalData <-
 #' @param indexURL character string http url for the bam file index,
 #' typically small
 #' @param deleteTracksOfSameName logical, default TRUE
-#' @param trackConfig a named list of additional igv.js track configuration options.
+#' @param trackConfig a named list of additional igv.js track configuration
+#' options.
 #'
 #' @examples
 #' library(igvShiny)
@@ -1163,7 +1186,8 @@ loadCramTrackFromURL <-
 #' @param visibilityWindow numeric, Maximum window size in base pairs
 #' for which indexed annotations or variants are displayed
 #' @param deleteTracksOfSameName logical, default TRUE
-#' @param trackConfig a named list of additional igv.js track configuration options.
+#' @param trackConfig a named list of additional igv.js track configuration
+#' options.
 #'
 #' @examples
 #' library(igvShiny)
@@ -1242,7 +1266,8 @@ loadGFF3TrackFromURL <-
 #' @param visibilityWindow numeric, Maximum window size in base pairs
 #' for which indexed annotations or variants are displayed
 #' @param deleteTracksOfSameName logical, default TRUE
-#' @param trackConfig a named list of additional igv.js track configuration options.
+#' @param trackConfig a named list of additional igv.js track configuration
+#' options.
 #'
 #' @examples
 #' library(igvShiny)

--- a/man/dot-sanitizeAndMergeOptions.Rd
+++ b/man/dot-sanitizeAndMergeOptions.Rd
@@ -12,7 +12,8 @@
 \item{userOptions}{A list of options provided by the user via trackConfig.}
 }
 \value{
-A merged and sanitized list of options ready to be sent to JavaScript.
+A merged and sanitized list of options ready to be sent to
+JavaScript.
 }
 \description{
 Sanitize and merge track configuration options

--- a/man/loadBamTrackFromLocalData.Rd
+++ b/man/loadBamTrackFromLocalData.Rd
@@ -28,7 +28,8 @@ loadBamTrackFromLocalData(
 \item{displayMode}{character string, possible values are "EXPANDED"(default),
 "SQUISHED" or "COLLAPSED"}
 
-\item{trackConfig}{a named list of additional igv.js track configuration options.}
+\item{trackConfig}{a named list of additional igv.js track configuration
+options.}
 }
 \value{
 nothing

--- a/man/loadBamTrackFromURL.Rd
+++ b/man/loadBamTrackFromURL.Rd
@@ -36,7 +36,8 @@ typically small}
 
 \item{showAllBases}{logical, show all bases in the alignment, default FALSE}
 
-\item{trackConfig}{a named list of additional igv.js track configuration options.}
+\item{trackConfig}{a named list of additional igv.js track configuration
+options.}
 }
 \value{
 nothing

--- a/man/loadBedGraphTrackFromURL.Rd
+++ b/man/loadBedGraphTrackFromURL.Rd
@@ -46,7 +46,8 @@ loadBedGraphTrackFromURL(
 
 \item{quiet}{logical, default TRUE, controls verbosity}
 
-\item{trackConfig}{a named list of additional igv.js track configuration options.}
+\item{trackConfig}{a named list of additional igv.js track configuration
+options.}
 }
 \value{
 nothing

--- a/man/loadBedTrack.Rd
+++ b/man/loadBedTrack.Rd
@@ -34,7 +34,8 @@ loadBedTrack(
 
 \item{quiet}{logical, default TRUE, controls verbosity}
 
-\item{trackConfig}{a named list of additional igv.js track configuration options.}
+\item{trackConfig}{a named list of additional igv.js track configuration
+options.}
 }
 \value{
 nothing

--- a/man/loadCramTrackFromURL.Rd
+++ b/man/loadCramTrackFromURL.Rd
@@ -29,7 +29,8 @@ typically small}
 
 \item{deleteTracksOfSameName}{logical, default TRUE}
 
-\item{trackConfig}{a named list of additional igv.js track configuration options.}
+\item{trackConfig}{a named list of additional igv.js track configuration
+options.}
 }
 \value{
 nothing

--- a/man/loadGFF3TrackFromLocalData.Rd
+++ b/man/loadGFF3TrackFromLocalData.Rd
@@ -46,7 +46,8 @@ for which indexed annotations or variants are displayed}
 
 \item{deleteTracksOfSameName}{logical, default TRUE}
 
-\item{trackConfig}{a named list of additional igv.js track configuration options.}
+\item{trackConfig}{a named list of additional igv.js track configuration
+options.}
 }
 \value{
 nothing

--- a/man/loadGFF3TrackFromURL.Rd
+++ b/man/loadGFF3TrackFromURL.Rd
@@ -51,7 +51,8 @@ for which indexed annotations or variants are displayed}
 
 \item{deleteTracksOfSameName}{logical, default TRUE}
 
-\item{trackConfig}{a named list of additional igv.js track configuration options.}
+\item{trackConfig}{a named list of additional igv.js track configuration
+options.}
 }
 \value{
 nothing

--- a/man/loadGenomeAnnotationTrack.Rd
+++ b/man/loadGenomeAnnotationTrack.Rd
@@ -47,7 +47,8 @@ loadBedGraphTrack(
 
 \item{quiet}{logical, default TRUE, controls verbosity}
 
-\item{trackConfig}{a named list of additional igv.js track configuration options.}
+\item{trackConfig}{a named list of additional igv.js track configuration
+options.}
 }
 \value{
 nothing

--- a/man/loadGwasTrack.Rd
+++ b/man/loadGwasTrack.Rd
@@ -31,7 +31,8 @@ loadGwasTrack(
 
 \item{deleteTracksOfSameName}{logical, default TRUE}
 
-\item{trackConfig}{a named list of additional igv.js track configuration options.}
+\item{trackConfig}{a named list of additional igv.js track configuration
+options.}
 }
 \value{
 nothing

--- a/man/loadSEGTrack.Rd
+++ b/man/loadSEGTrack.Rd
@@ -25,7 +25,8 @@ loadSegTrack(
 
 \item{deleteTracksOfSameName}{logical, default TRUE}
 
-\item{trackConfig}{a named list of additional igv.js track configuration options.}
+\item{trackConfig}{a named list of additional igv.js track configuration
+options.}
 }
 \value{
 nothing

--- a/man/loadVcfTrack.Rd
+++ b/man/loadVcfTrack.Rd
@@ -25,7 +25,8 @@ loadVcfTrack(
 
 \item{deleteTracksOfSameName}{logical, default TRUE}
 
-\item{trackConfig}{a named list of additional igv.js track configuration options.}
+\item{trackConfig}{a named list of additional igv.js track configuration
+options.}
 }
 \value{
 nothing


### PR DESCRIPTION
Closes the last NOTE standing between M1 and its acceptance criterion (`0 ERRORs, 0 WARNINGs, <=2 NOTEs`). CI was at 3 NOTEs; this removes the line-length one.

## What changed
- **25 over-long lines in `R/igvShiny.R`** wrapped at 80 characters — the allowlist vector, several roxygen `@param trackConfig` lines (11 identical ones), two long conditions and a handful of warning calls.
- **`paste()` moved out of the condition signals.** Wrapping the warnings the obvious way traded the line-length NOTE for a new one (`Avoid the use of 'paste' in condition signals`), so each message is now built into a local `fmt`/`msg` variable and passed to `warning()` already assembled. **The emitted message text is byte-identical** — no test or downstream string match changes.
- `man/*.Rd` regenerated by roxygen2 (the wrapped `@param` lines).
- `.gitignore`: ignore `*.BiocCheck/`, which BiocCheck writes into the package dir on every local run and then flags as an ERROR on the next one.
- DESCRIPTION 1.9.9 -> 1.9.10 + NEWS.

## Verification (local)
- `BiocCheck::BiocCheck(".")` -> **0 ERRORS**, line-length and paste NOTEs both gone. Remaining NOTEs are the pre-existing function-length and 4-space-indent ones, plus a local-only "cannot determine Bioc-Devel subscription". On CI that should read **2 NOTES**.
- `testthat::test_local()` -> 33 PASS. The single failure is `shinytest2` not being installed on this machine, not a code failure — CI covers it.
- No behaviour touched: the diff is line breaks plus three message-assembly variables.
