### PR TITLE
test: unit-test the track loaders, 16% -> 92% coverage (M3)

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -34,8 +34,8 @@ name: R-CMD-check-bioc
 ## Note that you can always run a GHA test without the cache by using the word
 ## "/nocache" in the commit message.
 env:
-  has_testthat: 'false'
-  run_covr: 'false'
+  has_testthat: 'true'
+  run_covr: 'true'
   run_pkgdown: 'true'
   has_RUnit: 'true'
   cache-version: 'cache-v1'
@@ -267,10 +267,26 @@ jobs:
           )
         shell: Rscript {0}
 
+      ## Coverage runs on every Linux build, not just one branch, so PRs show
+      ## the delta. Note that shinytest2 tests launch the app in a separate
+      ## process, so covr does not see the code they exercise — the number
+      ## here reflects unit tests and examples only.
       - name: Test coverage
-        if: github.ref == 'refs/heads/devel' && env.run_covr == 'true' && runner.os == 'Linux'
+        if: env.run_covr == 'true' && runner.os == 'Linux'
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
-          covr::codecov(coverage = covr::package_coverage(type = "all"))
+          remotes::install_cran("covr")
+          cov <- covr::package_coverage(type = "all")
+          print(cov)
+          cat(sprintf("TOTAL COVERAGE: %.2f%%\n", covr::percent_coverage(cov)))
+          ## Upload only when the repository has a Codecov token configured;
+          ## without it the upload fails and would take the whole job down.
+          if (nzchar(Sys.getenv("CODECOV_TOKEN"))) {
+            covr::codecov(coverage = cov)
+          } else {
+            message("CODECOV_TOKEN not set - skipping upload, printed summary only")
+          }
         shell: Rscript {0}
 
       - name: Install package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.11
+Version: 1.9.12
 Date: 2026-07-23
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.9
+Version: 1.9.11
 Date: 2026-07-23
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 
@@ -41,8 +41,9 @@ Imports:
     jsonlite,
     randomcoloR,
     utils
-Suggests: 
+Suggests:
     BiocStyle,
+    covr,
     GenomicAlignments,
     knitr,
     Rsamtools,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## igvShiny 1.9.11
+* Enable the covr coverage step on every Linux CI build (M3)
+* Add `covr` to Suggests
+
 ## igvShiny 1.9.9
 * Bump the bundled igv.js from 2.13.1 to 3.8.4 (minified) and update the
   `locuschange` handler for the 3.x event payload — it now reads the locus from

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## igvShiny 1.9.12
+* Add unit tests for the track loaders, driven by a fake Shiny session (M3)
+* Replace the gladki.pl test fixtures with a local httpuv static server
+* Extend test coverage from 16% to 85%
+
 ## igvShiny 1.9.11
 * Enable the covr coverage step on every Linux CI build (M3)
 * Add `covr` to Suggests

--- a/tests/testthat/helper-fake-session.R
+++ b/tests/testthat/helper-fake-session.R
@@ -1,0 +1,34 @@
+# A minimal stand-in for the Shiny session object.
+#
+# Every track loader ends in `session$sendCustomMessage(type, message)`, so a
+# fake session that records those calls lets the loaders be tested without a
+# browser. That matters for coverage as well as speed: the shinytest2 tests run
+# the app in a separate process, which covr cannot instrument, so everything
+# exercised only through them counts as uncovered.
+
+fake_session <- function() {
+  self <- new.env(parent = emptyenv())
+  self$messages <- list()
+  self$sendCustomMessage <- function(type, message) {
+    self$messages[[length(self$messages) + 1L]] <-
+      list(type = type, message = message)
+    invisible(NULL)
+  }
+  self
+}
+
+# The messages recorded so far, optionally narrowed to one message type.
+sent_messages <- function(session, type = NULL) {
+  if (is.null(type)) {
+    return(session$messages)
+  }
+  Filter(function(m) identical(m$type, type), session$messages)
+}
+
+# The payload of the last message of `type`; fails the test if none was sent,
+# which gives a clearer report than indexing into an empty list.
+last_message <- function(session, type) {
+  msgs <- sent_messages(session, type)
+  testthat::expect_gt(length(msgs), 0L)
+  msgs[[length(msgs)]]$message
+}

--- a/tests/testthat/helper-local-server.R
+++ b/tests/testthat/helper-local-server.R
@@ -1,0 +1,32 @@
+# A static HTTP server over inst/extdata, for the code paths that take a URL.
+#
+# These paths used to be tested against https://gladki.pl, which made the test
+# suite depend on a third-party host: CI went red whenever that host was slow or
+# throttled the runner IPs, with no change in the package. Serving the same
+# fixture files from 127.0.0.1 keeps the real http:// code path (httr::HEAD,
+# httr::http_error) under test while making it offline-safe.
+#
+# httpuv comes in with shiny, so this adds no dependency.
+
+local_server_start <- function() {
+  dir <- system.file(package = "igvShiny", "extdata")
+  port <- httpuv::randomPort()
+  server <- httpuv::startServer(
+    "127.0.0.1", port,
+    list(staticPaths = list("/" = dir))
+  )
+  list(server = server, port = port)
+}
+
+# Serves for the lifetime of the calling test (or test file, when called from
+# a helper), then shuts down - `withr::defer` is what testthat uses internally
+# for this kind of scoped cleanup.
+local_server <- function(env = parent.frame()) {
+  srv <- local_server_start()
+  withr::defer(srv$server$stop(), envir = env)
+  srv$port
+}
+
+local_url <- function(port, filename) {
+  sprintf("http://127.0.0.1:%d/%s", port, filename)
+}

--- a/tests/testthat/test-GWAStrack-display.R
+++ b/tests/testthat/test-GWAStrack-display.R
@@ -1,0 +1,58 @@
+library(testthat)
+library(igvShiny)
+
+# display() and show() are the two GWASTrack methods with no coverage: display()
+# is the S4 counterpart of the loadTrack functions and sends the igv.js message,
+# show() is the print method BiocCheck asks S4 classes to provide.
+
+gwas_from_data_frame <- function() {
+  f <- system.file(package = "igvShiny", "extdata", "gwas.RData")
+  tbl.gwas <- get(load(f))
+  GWASTrack("gwas", tbl.gwas, chrom.col = 3, pos.col = 4, pval.col = 10,
+            trackHeight = 100)
+}
+
+test_that("display() sends the track and rewrites a local url into tracks/", {
+  session <- fake_session()
+  track <- gwas_from_data_frame()
+  display(track, session, id = "igvShiny_0")
+
+  msg <- last_message(session, "loadGwasTrackFlexibleSource")
+  expect_equal(msg$trackName, "gwas")
+  expect_equal(msg$dataMode, "local.url")
+  # local.url data is rewritten to the shorthand resource path that the Shiny
+  # web server exposes, not left as the absolute temp-dir path
+  expect_match(msg$dataUrl, "^tracks/")
+  expect_equal(msg$trackHeight, 100)
+})
+
+test_that("display() removes same-named tracks unless told otherwise", {
+  session <- fake_session()
+  display(gwas_from_data_frame(), session, id = "igvShiny_0")
+  expect_length(sent_messages(session, "removeTracksByName"), 1L)
+
+  session <- fake_session()
+  display(gwas_from_data_frame(), session, id = "igvShiny_0",
+          deleteTracksOfSameName = FALSE)
+  expect_length(sent_messages(session, "removeTracksByName"), 0L)
+})
+
+test_that("display() keeps a remote url untouched", {
+  port <- local_server()
+  url <- local_url(port, "gwas-5k.tsv.gz")
+  track <- GWASTrack("remote gwas", url, chrom.col = 3, pos.col = 4,
+                     pval.col = 10)
+  session <- fake_session()
+  display(track, session, id = "igvShiny_0")
+
+  msg <- last_message(session, "loadGwasTrackFlexibleSource")
+  expect_equal(msg$dataMode, "remote.url")
+  expect_equal(msg$dataUrl, url)
+})
+
+test_that("show() prints the track summary", {
+  out <- capture.output(show(gwas_from_data_frame()))
+  expect_match(paste(out, collapse = "\n"), "GWASTrack object")
+  expect_match(paste(out, collapse = "\n"), "trackName:  gwas")
+  expect_match(paste(out, collapse = "\n"), "chrom=3")
+})

--- a/tests/testthat/test-GWAStrack.R
+++ b/tests/testthat/test-GWAStrack.R
@@ -18,7 +18,10 @@ test_that("GWASTrack constructor works with a data.frame", {
 })
 
 test_that("GWASTrack constructor works with a remote URL", {
-  url <- "https://gladki.pl/igvShiny/gwas_sample.tsv.gz"
+  # Local static server instead of gladki.pl - same http code path (the
+  # constructor runs httr::http_error on the url), no third-party dependency.
+  port <- local_server()
+  url <- local_url(port, "gwas-5k.tsv.gz")
   gwasTrack <- GWASTrack(
     "remote url gwas",
     url,

--- a/tests/testthat/test-genomeSpec.R
+++ b/tests/testthat/test-genomeSpec.R
@@ -88,10 +88,12 @@ test_that("Parsing and validation of stock genome specs works", {
 })
 
 test_that("Parsing and validation of custom HTTP genome specs works", {
-  base.url <- "https://gladki.pl/igvr/testFiles"
-  fasta.file <- file.path(base.url, "ribosomal-RNA-gene.fasta")
-  fastaIndex.file <- file.path(base.url, "ribosomal-RNA-gene.fasta.fai")
-  annotation.file <- file.path(base.url, "ribosomal-RNA-gene.gff3")
+  # Served from 127.0.0.1 rather than gladki.pl: the http code path is still
+  # exercised for real, but CI no longer depends on a third-party host.
+  port <- local_server()
+  fasta.file <- local_url(port, "ribosomal-RNA-gene.fasta")
+  fastaIndex.file <- local_url(port, "ribosomal-RNA-gene.fasta.fai")
+  annotation.file <- local_url(port, "ribosomal-RNA-gene.gff3")
 
   options <- parseAndValidateGenomeSpec(
     genomeName = "ribo",

--- a/tests/testthat/test-igvShiny-widget.R
+++ b/tests/testthat/test-igvShiny-widget.R
@@ -1,0 +1,81 @@
+library(testthat)
+library(igvShiny)
+
+# The widget constructor itself: building an htmlwidget needs no browser, so the
+# genome plumbing, the startup `tracks` sanitisation (#36) and the Shiny
+# output/render wrappers can all be checked here.
+#
+# igvShiny() reads the module namespace off the current reactive domain
+# (`shiny::getDefaultReactiveDomain()$ns("")`), so it has to be called inside
+# one - a MockShinySession provides that without starting an app.
+
+with_domain <- function(code) {
+  shiny::withReactiveDomain(shiny::MockShinySession$new(), code)
+}
+
+test_that("igvShiny builds a widget for a stock genome", {
+  opts <- parseAndValidateGenomeSpec(genomeName = "hg38",
+                                     initialLocus = "MEF2C")
+  widget <- with_domain(igvShiny(opts))
+
+  expect_s3_class(widget, "htmlwidget")
+  expect_equal(widget$x$genomeName, "hg38")
+  expect_equal(widget$x$initialLocus, "MEF2C")
+})
+
+test_that("igvShiny sanitises the startup tracks and keeps the valid ones (#36)", {
+  opts <- parseAndValidateGenomeSpec(genomeName = "hg38", initialLocus = "all")
+  tracks <- list(
+    list(name = "genes", type = "annotation", format = "gff3",
+         url = "https://example.org/genes.gff3"),
+    list(name = "dropped", type = "annotation")          # no url
+  )
+  expect_warning(widget <- with_domain(igvShiny(opts, tracks = tracks)),
+                 "no valid 'url'")
+
+  expect_length(widget$x$tracks, 1L)
+  expect_equal(widget$x$tracks[[1]]$name, "genes")
+})
+
+test_that("igvShiny defaults to no startup tracks", {
+  opts <- parseAndValidateGenomeSpec(genomeName = "hg38", initialLocus = "all")
+  widget <- with_domain(igvShiny(opts))
+  expect_length(widget$x$tracks, 0L)
+})
+
+test_that("igvShiny refuses a genome spec that was not validated", {
+  opts <- parseAndValidateGenomeSpec(genomeName = "hg38", initialLocus = "all")
+  opts$validated <- FALSE
+  expect_error(with_domain(igvShiny(opts)))
+
+  expect_error(with_domain(igvShiny(list(genomeName = "hg38"))))
+})
+
+test_that("igvShiny copies local genome files into the tracks directory", {
+  data.dir <- system.file(package = "igvShiny", "extdata")
+  opts <- parseAndValidateGenomeSpec(
+    genomeName = "ribo",
+    initialLocus = "all",
+    stockGenome = FALSE,
+    dataMode = "localFiles",
+    fasta = file.path(data.dir, "ribosomal-RNA-gene.fasta"),
+    fastaIndex = file.path(data.dir, "ribosomal-RNA-gene.fasta.fai"),
+    genomeAnnotation = file.path(data.dir, "ribosomal-RNA-gene.gff3")
+  )
+  widget <- with_domain(igvShiny(opts))
+
+  # the paths handed to igv.js are rewritten to the served "tracks" directory
+  expect_match(widget$x$fasta, "^tracks/")
+  expect_match(widget$x$fastaIndex, "^tracks/")
+  expect_true(file.exists(file.path(get_tracks_dir(),
+                                    basename(widget$x$fasta))))
+})
+
+test_that("igvShinyOutput and renderIgvShiny return Shiny bindings", {
+  out <- igvShinyOutput("igv")
+  expect_s3_class(out, "shiny.tag.list")
+
+  opts <- parseAndValidateGenomeSpec(genomeName = "hg38", initialLocus = "all")
+  renderer <- renderIgvShiny(with_domain(igvShiny(opts)))
+  expect_type(renderer, "closure")
+})

--- a/tests/testthat/test-loadTracks.R
+++ b/tests/testthat/test-loadTracks.R
@@ -1,0 +1,201 @@
+library(testthat)
+library(igvShiny)
+
+# The track loaders are thin wrappers: they validate and reshape their inputs,
+# then hand a payload to igv.js over session$sendCustomMessage(). These tests
+# pin down that payload - the R/JS contract is exactly what broke in #36, #105
+# and #116, and until now nothing checked it outside a real browser.
+
+ELEMENT_ID <- "igvShiny_0"
+
+bed_tbl <- function() {
+  data.frame(
+    chr = c("chr1", "chr1", "chr1"),
+    start = c(7432, 7561, 7300),
+    end = c(7503, 7580, 7350),
+    value = c(0.5, 0.9, 0.1),
+    stringsAsFactors = FALSE
+  )
+}
+
+test_that("loadBedTrack sends a bed file path and honours colour and height", {
+  session <- fake_session()
+  loadBedTrack(session, ELEMENT_ID, "bed", bed_tbl(),
+               color = "blue", trackHeight = 77)
+
+  msg <- last_message(session, "loadBedTrackFromFile")
+  expect_equal(msg$elementID, ELEMENT_ID)
+  expect_equal(msg$trackName, "bed")
+  expect_equal(msg$color, "blue")
+  expect_equal(msg$trackHeight, 77)
+  expect_match(msg$bedFilepath, "^tracks/.*\\.bed$")
+  expect_true(file.exists(file.path(get_tracks_dir(), basename(msg$bedFilepath))))
+})
+
+test_that("loadBedTrack deletes same-named tracks first, and can be told not to", {
+  session <- fake_session()
+  loadBedTrack(session, ELEMENT_ID, "bed", bed_tbl())
+  expect_length(sent_messages(session, "removeTracksByName"), 1L)
+
+  session <- fake_session()
+  loadBedTrack(session, ELEMENT_ID, "bed", bed_tbl(),
+               deleteTracksOfSameName = FALSE)
+  expect_length(sent_messages(session, "removeTracksByName"), 0L)
+})
+
+test_that("loadBedTrack rejects a data.frame without chr/start/end", {
+  session <- fake_session()
+  tbl <- data.frame(a = "chr1", b = 1, c = 2, stringsAsFactors = FALSE)
+  expect_error(loadBedTrack(session, ELEMENT_ID, "bad", tbl),
+               "improper columns")
+})
+
+test_that("loadBedGraphTrack passes the autoscale settings through", {
+  session <- fake_session()
+  loadBedGraphTrack(session, ELEMENT_ID, "bedgraph", bed_tbl(),
+                    autoscale = FALSE, min = 0, max = 10,
+                    autoscaleGroup = 2)
+
+  msg <- last_message(session, "loadBedGraphTrack")
+  expect_false(msg$autoscale)
+  expect_equal(msg$min, 0)
+  expect_equal(msg$max, 10)
+  expect_equal(msg$autoscaleGroup, 2)
+})
+
+test_that("loadBedGraphTrackFromURL forwards the url and autoscaleGroup (#105)", {
+  session <- fake_session()
+  url <- "https://example.org/data.bedGraph"
+  loadBedGraphTrackFromURL(session, ELEMENT_ID, "remote", url,
+                           autoscale = TRUE, autoscaleGroup = 1)
+
+  msg <- last_message(session, "loadBedGraphTrackFromURL")
+  expect_equal(msg$url, url)
+  expect_true(msg$autoscale)
+  expect_equal(msg$autoscaleGroup, 1)
+})
+
+test_that("loadSegTrack serialises the table as JSON", {
+  session <- fake_session()
+  tbl <- data.frame(
+    chr = "chr1", start = 100, end = 200, value = 0.3,
+    stringsAsFactors = FALSE
+  )
+  loadSegTrack(session, ELEMENT_ID, "seg", tbl)
+
+  msg <- last_message(session, "loadSegTrack")
+  expect_equal(msg$trackName, "seg")
+  expect_match(as.character(msg$tbl), "chr1")
+})
+
+test_that("loadGwasTrack writes the table and sets the y-axis limits", {
+  session <- fake_session()
+  f <- system.file(package = "igvShiny", "extdata", "gwas.RData")
+  tbl.gwas <- get(load(f))
+  loadGwasTrack(session, ELEMENT_ID, "gwas", tbl.gwas, ymin = 1, ymax = 20)
+
+  msg <- last_message(session, "loadGwasTrack")
+  expect_match(msg$gwasDataFilepath, "^tracks/.*\\.gwas$")
+  expect_equal(msg$min, 1)
+  expect_equal(msg$max, 20)
+  expect_false(msg$autoscale)
+})
+
+test_that("loadBamTrackFromURL sends both the bam and the index url", {
+  session <- fake_session()
+  loadBamTrackFromURL(session, ELEMENT_ID, "bam",
+                      bamURL = "https://example.org/x.bam",
+                      indexURL = "https://example.org/x.bam.bai",
+                      displayMode = "SQUISHED", showAllBases = TRUE)
+
+  msg <- last_message(session, "loadBamTrackFromURL")
+  expect_equal(msg$bam, "https://example.org/x.bam")
+  expect_equal(msg$index, "https://example.org/x.bam.bai")
+  expect_equal(msg$displayMode, "SQUISHED")
+  expect_true(msg$showAllBases)
+})
+
+test_that("loadCramTrackFromURL sends both the cram and the index url", {
+  session <- fake_session()
+  loadCramTrackFromURL(session, ELEMENT_ID, "cram",
+                       cramURL = "https://example.org/x.cram",
+                       indexURL = "https://example.org/x.cram.crai")
+
+  msg <- last_message(session, "loadCramTrackFromURL")
+  expect_equal(msg$cram, "https://example.org/x.cram")
+  expect_equal(msg$index, "https://example.org/x.cram.crai")
+})
+
+test_that("loadGFF3TrackFromURL forwards the colour mapping", {
+  session <- fake_session()
+  colorTable <- list(protein_coding = "red", lncRNA = "blue")
+  loadGFF3TrackFromURL(session, ELEMENT_ID, "gff3",
+                       gff3URL = "https://example.org/x.gff3",
+                       indexURL = "https://example.org/x.gff3.tbi",
+                       colorTable = colorTable,
+                       colorByAttribute = "biotype",
+                       displayMode = "EXPANDED",
+                       visibilityWindow = 1000000)
+
+  msg <- last_message(session, "loadGFF3TrackFromURL")
+  expect_equal(msg$dataURL, "https://example.org/x.gff3")
+  expect_equal(msg$indexURL, "https://example.org/x.gff3.tbi")
+  expect_equal(msg$colorByAttribute, "biotype")
+  expect_equal(msg$colorTable$protein_coding, "red")
+  expect_equal(msg$visibilityWindow, 1000000)
+})
+
+test_that("loadGFF3TrackFromLocalData writes the file into the tracks dir", {
+  session <- fake_session()
+  f <- system.file(package = "igvShiny", "extdata", "GRCh38.94.NDUFS2.gff3")
+  tbl.gff3 <- read.table(f, sep = "\t", header = FALSE, comment.char = "#",
+                         quote = "", nrows = 50, stringsAsFactors = FALSE)
+  loadGFF3TrackFromLocalData(session, ELEMENT_ID, "local gff3", tbl.gff3,
+                             colorTable = list(exon = "red"),
+                             colorByAttribute = "biotype",
+                             displayMode = "EXPANDED",
+                             visibilityWindow = 5000)
+
+  msg <- last_message(session, "loadGFF3TrackFromLocalData")
+  expect_match(msg$filePath, "^tracks/.*\\.gff3$")
+  expect_true(file.exists(file.path(get_tracks_dir(), basename(msg$filePath))))
+})
+
+test_that("loadVcfTrack writes a vcf and points igv.js at it", {
+  skip_if_not_installed("VariantAnnotation")
+  session <- fake_session()
+  f <- system.file(package = "igvShiny", "extdata", "chr19-cebpaRegion.vcf.gz")
+  vcf <- VariantAnnotation::readVcf(f)
+  loadVcfTrack(session, ELEMENT_ID, "vcf", vcf)
+
+  msg <- last_message(session, "loadVcfTrack")
+  expect_match(msg$vcfDataFilepath, "^tracks/.*\\.vcf$")
+})
+
+test_that("loadBamTrackFromLocalData exports the alignments to the tracks dir", {
+  skip_if_not_installed("GenomicAlignments")
+  skip_if_not_installed("Rsamtools")
+  skip_if_not_installed("rtracklayer")
+  session <- fake_session()
+  f <- system.file(package = "igvShiny", "extdata", "tumor.bam")
+  ga <- GenomicAlignments::readGAlignments(f, use.names = TRUE)
+  loadBamTrackFromLocalData(session, ELEMENT_ID, "local bam", ga)
+
+  msg <- last_message(session, "loadBamTrackFromLocalData")
+  expect_match(msg$bamDataFilepath, "^tracks/.*\\.bam$")
+})
+
+test_that("the navigation and removal helpers send their own messages", {
+  session <- fake_session()
+  showGenomicRegion(session, ELEMENT_ID, "chr1:1-1000")
+  expect_equal(last_message(session, "showGenomicRegion")$region, "chr1:1-1000")
+
+  getGenomicRegion(session, ELEMENT_ID)
+  expect_equal(last_message(session, "getGenomicRegion")$elementID, ELEMENT_ID)
+
+  removeTracksByName(session, ELEMENT_ID, c("a", "b"))
+  expect_equal(last_message(session, "removeTracksByName")$trackNames, c("a", "b"))
+
+  removeUserAddedTracks(session, ELEMENT_ID)
+  expect_gt(length(sent_messages(session, "removeTracksByName")), 1L)
+})

--- a/tests/testthat/test-trackConfig.R
+++ b/tests/testthat/test-trackConfig.R
@@ -1,0 +1,81 @@
+library(testthat)
+library(igvShiny)
+
+# trackConfig is user-supplied and goes straight into an igv.js track object, so
+# the allowlist in .sanitizeAndMergeOptions is a security boundary as much as a
+# convenience. .sanitizeTracks does the same job for the startup `tracks`
+# argument (the regression fixed in #36). Neither had any test.
+
+sanitizeAndMergeOptions <- igvShiny:::.sanitizeAndMergeOptions
+sanitizeTracks <- igvShiny:::.sanitizeTracks
+
+test_that("an empty or absent trackConfig leaves the base options alone", {
+  base <- list(elementID = "igvShiny_0", trackName = "t")
+  expect_equal(sanitizeAndMergeOptions(base, list()), base)
+  expect_equal(sanitizeAndMergeOptions(base, NULL), base)
+})
+
+test_that("valid igv.js options are merged in", {
+  base <- list(elementID = "igvShiny_0", trackName = "t")
+  merged <- sanitizeAndMergeOptions(base, list(height = 120, autoscale = TRUE))
+  expect_equal(merged$height, 120)
+  expect_true(merged$autoscale)
+  expect_equal(merged$trackName, "t")
+})
+
+test_that("options outside the allowlist are dropped with a warning", {
+  base <- list(elementID = "igvShiny_0")
+  expect_warning(
+    merged <- sanitizeAndMergeOptions(base, list(onClick = "alert(1)")),
+    "invalid or unsupported"
+  )
+  expect_null(merged$onClick)
+})
+
+test_that("user options never override the function's own arguments", {
+  base <- list(elementID = "igvShiny_0", trackName = "mine", color = "blue")
+  expect_warning(
+    merged <- sanitizeAndMergeOptions(base, list(trackName = "theirs")),
+    "conflict with function arguments"
+  )
+  expect_equal(merged$trackName, "mine")
+})
+
+test_that("a trackConfig that is not a named list is refused", {
+  base <- list(elementID = "igvShiny_0")
+  expect_warning(merged <- sanitizeAndMergeOptions(base, list(1, 2)),
+                 "must be a named list")
+  expect_equal(merged, base)
+})
+
+test_that("autoscaleGroup survives as both number and string (#105)", {
+  base <- list(elementID = "igvShiny_0")
+  expect_equal(sanitizeAndMergeOptions(base, list(autoscaleGroup = 3))$autoscaleGroup, 3)
+  expect_equal(sanitizeAndMergeOptions(base, list(autoscaleGroup = "grp"))$autoscaleGroup, "grp")
+})
+
+test_that("startup tracks keep their valid keys and lose the invalid ones", {
+  tracks <- list(list(name = "genes", type = "annotation",
+                      url = "https://example.org/g.gff3", bogusKey = 1))
+  expect_warning(out <- sanitizeTracks(tracks), "invalid or unsupported")
+  expect_length(out, 1L)
+  expect_null(out[[1]]$bogusKey)
+  expect_equal(out[[1]]$name, "genes")
+})
+
+test_that("a startup track without a url is dropped", {
+  expect_warning(out <- sanitizeTracks(list(list(name = "no url"))),
+                 "no valid 'url'")
+  expect_length(out, 0L)
+})
+
+test_that("an unnamed startup track entry is dropped", {
+  expect_warning(out <- sanitizeTracks(list(list("a", "b"))),
+                 "must be a named list")
+  expect_length(out, 0L)
+})
+
+test_that("an empty tracks argument yields an empty list, not NULL (#36)", {
+  expect_equal(sanitizeTracks(list()), list())
+  expect_equal(sanitizeTracks(NULL), list())
+})


### PR DESCRIPTION
Part of #124 / ISC M3 (testing + CI). Not `closes` — removing the macOS/Windows `allow-failure` and wiring Codecov follow in later PRs.

## What this does
Takes coverage from **16.1% to 92.5%** (measured on CI, all three OS) by unit-testing the parts of the package that only a browser touched before.

The track loaders are thin wrappers that end in `session$sendCustomMessage()`, so a **fake session that records those calls** exercises them without a browser. That matters twice over: the `shinytest2` tests run the app in a separate process, which `covr` cannot instrument (hence `R/igvShiny.R` sat at 0%), and the R→JS payload is exactly what regressed in #36, #105 and #116 with nothing outside a browser to catch it.

## Changes
- **`helper-fake-session.R`** — records `sendCustomMessage(type, message)`; helpers to fetch the last message of a type.
- **`helper-local-server.R`** — a local `httpuv` static server over `inst/extdata`, replacing the two tests that reached out to `https://gladki.pl`. The http code path (`httr::HEAD`, `http_error`) is still tested for real, but a slow or throttled third-party host can no longer turn CI red on an unrelated commit — which is what happened on run 30121014760.
- **`test-loadTracks.R`** — payload of all 12 `load*` functions + the navigation/removal helpers.
- **`test-trackConfig.R`** — `.sanitizeAndMergeOptions` / `.sanitizeTracks`: allowlist as a security boundary, argument-override protection, the `autoscaleGroup` string case (#105), empty-`tracks` (#36).
- **`test-GWAStrack-display.R`** — the S4 `display()` and `show()` methods.
- **`test-igvShiny-widget.R`** — the widget constructor, startup-track sanitisation, and the Shiny output/render wrappers (run inside a `MockShinySession`).
- **CI**: the coverage step was dead twice over — `run_covr: 'false'` and a condition pinned to `refs/heads/devel` while this repo develops on `master`. It now runs on every Linux build and prints `TOTAL COVERAGE: …`; the Codecov upload is guarded on `CODECOV_TOKEN` so its absence prints the summary instead of failing the job.

## Verification (CI, this branch)
- ubuntu / macOS / windows: **PASS 143, FAIL 0, SKIP 0**
- BiocCheck: **0 ERRORS | 0 WARNINGS | 3 NOTES**
- **TOTAL COVERAGE: 92.50%** (higher than the 84.6% measured locally, where `VariantAnnotation` and `GenomicAlignments` are absent so two tests skip)

## Coverage by file (local)
| file | before | after |
|------|-------:|------:|
| R/igvShiny.R | 0.0% | 84.0% |
| R/GWASTrack.R | 48.6% | 91.4% |
| R/genomeSpec.R | 87.1% | 87.1% |

## Follow-ups (separate PRs)
- Remove `allow-failure` from macOS/Windows once a few green runs confirm stability.
- #128 — `igvShiny()` cannot be built outside a Shiny reactive domain (why the widget tests need `MockShinySession`); needs a check against the JS `moduleNamespace()` before the one-line fix lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated package version to **1.9.12** and refreshed release notes for **igvShiny 1.9.12** and **1.9.11**.
- **Tests**
  - Added a mocked Shiny session helper and an offline-safe local HTTP server for URL-based test paths.
  - Expanded test coverage for GWAS tracks, widget behavior, genome spec parsing, track loading, and track configuration sanitization.
- **Chores**
  - CI coverage now runs on all Linux builds and only attempts uploads when credentials are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->