### PR TITLE
fix: harden trackConfig/tracks input validation (CodeRabbit on #127)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.12
+Version: 1.9.13
 Date: 2026-07-23
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## igvShiny 1.9.13
-* Reject NA or empty names in `trackConfig`, warning instead of erroring
-* Require a startup track `url` to be a non-empty scalar string
+* Prevent NA or empty names in `trackConfig`, warning instead of erroring
+* Enforce a non-empty scalar string for the startup track `url`
 
 ## igvShiny 1.9.12
 * Add unit tests for the track loaders, driven by a fake Shiny session (M3)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## igvShiny 1.9.13
+* Reject NA or empty names in `trackConfig`, warning instead of erroring
+* Require a startup track `url` to be a non-empty scalar string
+
 ## igvShiny 1.9.12
 * Add unit tests for the track loaders, driven by a fake Shiny session (M3)
 * Replace the gladki.pl test fixtures with a local httpuv static server

--- a/R/igvShiny.R
+++ b/R/igvShiny.R
@@ -35,8 +35,10 @@
     return(baseOptions)
   }
 
+  # anyNA guards the NA-name case: without it, `any(names == "")` evaluates to
+  # NA when a name is NA and the `if` errors instead of warning and ignoring.
   if (!is.list(userOptions) || is.null(names(userOptions)) ||
-      any(names(userOptions) == "")) {
+      anyNA(names(userOptions)) || any(names(userOptions) == "")) {
     warning("trackConfig must be a named list. Ignoring.")
     return(baseOptions)
   }
@@ -90,7 +92,12 @@
       warning(sprintf(fmt, toString(invalidKeys)))
       track[invalidKeys] <- NULL
     }
-    if (is.null(track[["url"]])) {
+    # A usable url is a single non-empty, non-NA character string. is.null()
+    # alone let NA, "", character(0) and non-character values through to
+    # igv.js as broken tracks.
+    url <- track[["url"]]
+    if (!is.character(url) || length(url) != 1L || is.na(url) ||
+        !nzchar(url)) {
       msg <- paste("Dropping entry in 'tracks' with no valid 'url' after",
                    "removing unsupported options.")
       warning(msg)

--- a/tests/testthat/test-sanitizer-validation.R
+++ b/tests/testthat/test-sanitizer-validation.R
@@ -1,0 +1,39 @@
+library(testthat)
+library(igvShiny)
+
+# Edge cases in the two input sanitizers, flagged by review on #127. Both are
+# pure functions, so they need no Shiny session.
+
+sanitizeAndMergeOptions <- igvShiny:::.sanitizeAndMergeOptions
+sanitizeTracks <- igvShiny:::.sanitizeTracks
+
+test_that("a NA-named trackConfig warns and is ignored, not an error", {
+  base <- list(elementID = "igvShiny_0")
+  bad <- list(1)
+  names(bad) <- NA_character_
+  # before the fix this raised "missing value where TRUE/FALSE needed"
+  expect_warning(out <- sanitizeAndMergeOptions(base, bad),
+                 "must be a named list")
+  expect_equal(out, base)
+})
+
+test_that("a startup track url must be a non-empty scalar string", {
+  for (bad_url in list(NA_character_, "", character(0))) {
+    expect_warning(out <- sanitizeTracks(list(list(name = "t", url = bad_url))),
+                   "no valid 'url'")
+    expect_length(out, 0L)
+  }
+})
+
+test_that("a non-character startup track url is rejected", {
+  expect_warning(out <- sanitizeTracks(list(list(name = "t", url = 42))),
+                 "no valid 'url'")
+  expect_length(out, 0L)
+})
+
+test_that("a valid scalar url is still kept", {
+  out <- sanitizeTracks(list(list(name = "t",
+                                  url = "https://example.org/x.bed")))
+  expect_length(out, 1L)
+  expect_equal(out[[1]]$url, "https://example.org/x.bed")
+})

--- a/tests/testthat/test-sanitizer-validation.R
+++ b/tests/testthat/test-sanitizer-validation.R
@@ -31,6 +31,21 @@ test_that("a non-character startup track url is rejected", {
   expect_length(out, 0L)
 })
 
+test_that("a multi-valued startup track url is rejected", {
+  expect_warning(
+    out <- sanitizeTracks(list(list(name = "t",
+                                    url = c("https://a.bed", "https://b.bed")))),
+    "no valid 'url'"
+  )
+  expect_length(out, 0L)
+})
+
+test_that("a startup track with no url field is dropped", {
+  expect_warning(out <- sanitizeTracks(list(list(name = "t"))),
+                 "no valid 'url'")
+  expect_length(out, 0L)
+})
+
 test_that("a valid scalar url is still kept", {
   out <- sanitizeTracks(list(list(name = "t",
                                   url = "https://example.org/x.bed")))


### PR DESCRIPTION
Fixes the two edge cases CodeRabbit flagged on #127, both verified against the current code.

## The bugs
1. **`.sanitizeAndMergeOptions`** — `any(names(userOptions) == "")` evaluates to `NA` when a name is `NA`, so `if (... )` failed with `missing value where TRUE/FALSE needed` instead of warning and returning `baseOptions`. A `trackConfig` with an `NA` name crashed the loader. Fixed by adding `anyNA(names(userOptions))`, matching the guard already present in `.sanitizeTracks`.
2. **`.sanitizeTracks`** — `is.null(track[["url"]])` only caught `NULL`, so `NA`, `""`, `character(0)` and non-character values passed through and reached igv.js as broken startup tracks. Now the url must be a non-empty scalar character string.

Both were reproduced before the fix:
```
NA-named trackConfig  -> ERROR: missing value where TRUE/FALSE needed
url = NA / "" / character(0) -> kept (should be dropped)
```

## Tests
`test-sanitizer-validation.R` — both functions are pure, so no Shiny session is needed. Covers the NA-name error path, each unusable-url case, a non-character url, and that a valid scalar url still survives.

## Verification (local)
- `testthat::test_local()` — the new cases pass; the only failure is `shinytest2` not installed on this machine (CI has it).
- `BiocCheck` — 0 ERRORS, line-length still clean.

## Notes for whoever merges
Branched off `master` (post-#127), independent of the M3 test PR #129 as agreed (that one stays test-only). Two expected interactions:
- **Version/NEWS collision with #129** — both bump from 1.9.10; whichever lands second needs a trivial DESCRIPTION/NEWS rebase.
- This branch still carries the pre-existing `gladki.pl` tests (the local-server replacement is in #129), so CI here can flake on that third-party host until #129 merges — unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for track configuration names, now warning and ignoring `NA`/empty/invalid names instead of failing.
  * Strengthened startup track URL validation: startup tracks are rejected unless `url` is a single, non-`NA`, non-empty character string; invalid entries trigger warnings.
* **Documentation**
  * Updated release notes to reflect the new validation behavior.
* **Tests**
  * Added test coverage for sanitizer edge cases around track names and startup `url` handling.
* **Chores**
  * Bumped the package version to 1.9.13.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->