### PR TITLE
fix: build igvShiny() outside a shiny session (#128)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.13
+Version: 1.9.14
 Date: 2026-07-23
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## igvShiny 1.9.14
+* Allow `igvShiny()` to build outside a shiny session, for scripts and vignettes
+
 ## igvShiny 1.9.13
 * Prevent NA or empty names in `trackConfig`, warning instead of erroring
 * Enforce a non-empty scalar string for the startup track `url`

--- a/R/igvShiny.R
+++ b/R/igvShiny.R
@@ -208,7 +208,10 @@ igvShiny <- function(genomeOptions,
   genomeOptions$displayMode <- displayMode
   genomeOptions$trackHeight <-
     100      # todo: make this an igvShiny ctor argument
-  genomeOptions$moduleNS <- session$ns("")
+  # outside a shiny session (script, vignette) there is no namespace to prepend;
+  # the JS side concatenates moduleNS with the event name, so "" is the no-module
+  # case
+  genomeOptions$moduleNS <- if (is.null(session)) "" else session$ns("")
   genomeOptions$tracks <- .sanitizeTracks(tracks)
 
   htmlwidgets::createWidget(

--- a/R/igvShiny.R
+++ b/R/igvShiny.R
@@ -208,9 +208,9 @@ igvShiny <- function(genomeOptions,
   genomeOptions$displayMode <- displayMode
   genomeOptions$trackHeight <-
     100      # todo: make this an igvShiny ctor argument
-  # outside a shiny session (script, vignette) there is no namespace to prepend;
-  # the JS side concatenates moduleNS with the event name, so "" is the no-module
-  # case
+  # outside a shiny session (script, vignette) there is no namespace to
+  # prepend; the JS side concatenates moduleNS with the event name, so the
+  # no-module case is the empty string
   genomeOptions$moduleNS <- if (is.null(session)) "" else session$ns("")
   genomeOptions$tracks <- .sanitizeTracks(tracks)
 

--- a/tests/testthat/test-igvShiny-widget.R
+++ b/tests/testthat/test-igvShiny-widget.R
@@ -6,8 +6,8 @@ library(igvShiny)
 # output/render wrappers can all be checked here.
 #
 # igvShiny() reads the module namespace off the current reactive domain
-# (`shiny::getDefaultReactiveDomain()$ns("")`), so it has to be called inside
-# one - a MockShinySession provides that without starting an app.
+# (`shiny::getDefaultReactiveDomain()$ns("")`); a MockShinySession provides one
+# without starting an app. Outside a session the namespace is "" (#128).
 
 with_domain <- function(code) {
   shiny::withReactiveDomain(shiny::MockShinySession$new(), code)
@@ -69,6 +69,17 @@ test_that("igvShiny copies local genome files into the tracks directory", {
   expect_match(widget$x$fastaIndex, "^tracks/")
   expect_true(file.exists(file.path(get_tracks_dir(),
                                     basename(widget$x$fasta))))
+})
+
+test_that("igvShiny builds outside a reactive domain (#128)", {
+  expect_null(shiny::getDefaultReactiveDomain())
+
+  opts <- parseAndValidateGenomeSpec(genomeName = "hg38", initialLocus = "all")
+  widget <- igvShiny(opts)
+
+  expect_s3_class(widget, "htmlwidget")
+  # the JS side concatenates moduleNS with the event name, so no module means ""
+  expect_identical(widget$x$moduleNS, "")
 })
 
 test_that("igvShinyOutput and renderIgvShiny return Shiny bindings", {


### PR DESCRIPTION
Closes #128.

`igvShiny()` read the module namespace off the current reactive domain unconditionally:

```r
session <- shiny::getDefaultReactiveDomain()
genomeOptions$moduleNS <- session$ns("")
```

Outside a Shiny session `getDefaultReactiveDomain()` returns `NULL`, so this became `NULL$ns("")` and failed with `attempt to apply non-function`. That blocks building the widget from a plain script or a vignette (relevant for the M4 docs work).

## Fix

```r
genomeOptions$moduleNS <- if (is.null(session)) "" else session$ns("")
```

The empty string is the correct no-module value: the JS side treats `moduleNS` as a prefix and simply concatenates it with the event name (`moduleNamespace()` in `inst/htmlwidgets/igvShiny.js`), so `""` yields the bare event names (`igvReady`, `trackClick`, …) — the same ones already sent unprefixed alongside the namespaced variants.

## Test

`test-igvShiny-widget.R` gains a case that builds the widget with no reactive domain active and asserts `moduleNS == ""`. Local run: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 17 ]` for that file.

Deliberately kept to one concern, separate from the M3 test work (#129/#130), so it stays trivial to review and revert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `igvShiny()` can now be created outside a Shiny reactive session (e.g., scripts and vignettes).
  * Maintains compatible widget behavior when used within a Shiny session.

* **Bug Fixes**
  * Fixed widget namespace handling when no reactive domain is available.

* **Tests**
  * Added/updated tests to verify widget creation without an active Shiny session, including expected namespace behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->