### PR TITLE
chore: configure CodeRabbit and check external assets on a schedule (#115)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,6 +6,7 @@
 ^doc$
 ^Meta$
 ^AGENTS\.md$
+^\.coderabbit\.yaml$
 ^Containerfile$
 ^\.serena$
 ^CLAUDE\.md$

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,58 @@
+# CodeRabbit configuration for igvShiny.
+# Rationale and rejected alternatives: issue #115.
+language: en-GB
+
+reviews:
+  # Default is "chill", which produced zero inline comments on #114 without
+  # telling us whether it was correctly silent or simply not looking. There is
+  # no second human reviewer here, so prefer the noisier profile and discard
+  # what does not apply.
+  profile: assertive
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  auto_review:
+    enabled: true
+    drafts: false
+
+  path_filters:
+    # Vendored igv.js (~8.7 MB minified) is third-party code we only bump as a
+    # whole; reviewing its diff is pure noise. See inst/htmlwidgets/igvShiny.yaml
+    # for the version actually in use.
+    - "!inst/htmlwidgets/lib/**"
+    - "!man/**"
+    - "!NAMESPACE"
+
+  path_instructions:
+    - path: "R/**"
+      instructions: >
+        R package released through Bioconductor. Every exported function needs
+        Roxygen2 documentation with @examples; man/*.Rd and NAMESPACE are
+        generated, never hand-edited. Flag missing tests in tests/testthat for
+        new behaviour. Do not propose tidyverse-style rewrites: the codebase
+        uses base R plus Bioconductor idioms deliberately.
+    - path: "inst/htmlwidgets/igvShiny.js"
+      instructions: >
+        Browser side of the R <-> JS bridge. Options crossing the bridge are
+        filtered in R by .sanitizeAndMergeOptions() against an allowlist and
+        merged in JS by mergeExtraParameters(); a new option is only reachable
+        if both sides know about it. The bundled igv.js version is pinned in
+        inst/htmlwidgets/igvShiny.yaml — verify the vendored library supports a
+        config key before suggesting it, rather than assuming the latest
+        upstream API.
+    - path: "tests/testthat/**"
+      instructions: >
+        testthat. Loader tests drive a fake Shiny session (helper-fake-session.R)
+        that records sendCustomMessage payloads; HTTP fixtures are served by a
+        local httpuv server (helper-local-server.R). Flag any new dependency on
+        an external host — remote fixtures have broken CI before (#129).
+    - path: "NEWS.md"
+      instructions: >
+        Linted by gDRstyle::lintNewsEntries before R CMD check runs. Each bullet
+        starts with an imperative verb from the gDRstyle whitelist, is at most
+        120 characters, has no trailing full stop, and there are at most three
+        bullets per version section.
+
+chat:
+  auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -38,9 +38,10 @@ reviews:
         filtered in R by .sanitizeAndMergeOptions() against an allowlist and
         merged in JS by mergeExtraParameters(); a new option is only reachable
         if both sides know about it. The bundled igv.js version is pinned in
-        inst/htmlwidgets/igvShiny.yaml — verify the vendored library supports a
-        config key before suggesting it, rather than assuming the latest
-        upstream API.
+        inst/htmlwidgets/igvShiny.yaml and the library itself is out of review
+        scope, so do not assume the latest upstream API: when a suggestion
+        depends on igv.js supporting a config key, say so and ask the author to
+        confirm it against the pinned version.
     - path: "tests/testthat/**"
       instructions: >
         testthat. Loader tests drive a fake Shiny session (helper-fake-session.R)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+<!--
+Use "Related: #NNN" rather than "Fixes #NNN": a PR often addresses part of an
+issue, and auto-closing has hidden unfinished work before (#36). Close issues by
+hand once the work is genuinely complete.
+-->
+
+Related: #
+
+## What changed
+
+<!-- What the diff does, and why this approach. -->
+
+## How it was verified
+
+<!-- Tests run, demo exercised, CI jobs, manual checks. -->
+
+- [ ] `testthat::test_local()` passes locally (run `R CMD INSTALL .` first — shinytest2 tests load the *installed* package)
+- [ ] `roxygen2::roxygenise()` re-run if anything in `R/` changed
+- [ ] `NEWS.md` entry added (imperative verb, ≤120 chars, no trailing full stop)

--- a/.github/scripts/check-asset-urls.sh
+++ b/.github/scripts/check-asset-urls.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Check that the external assets igvShiny points at are still reachable.
+#
+# Stock genomes, example fasta/gff3 files and demo tracks live on hosts we do
+# not control (gladki.pl, igv.org, AWS, UCSC, ENCODE). When one starts to 404
+# the package keeps passing its tests — the tests deliberately use a local
+# httpuv server — but genomes silently fail to display for users. That is how
+# #107 reached us, as a bug report. See issue #115.
+#
+# URLs are scraped from the sources rather than listed here, so the check
+# cannot drift away from what the code actually requests.
+#
+# Usage: .github/scripts/check-asset-urls.sh [--markdown]
+# Exit:  0 all reachable, 1 at least one failed.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+markdown=false
+[[ "${1:-}" == "--markdown" ]] && markdown=true
+
+# Sources that carry URLs igv.js will actually fetch. The vendored library in
+# inst/htmlwidgets/lib is excluded: those are upstream's own URLs, thousands of
+# them, and not ours to fix.
+sources=(
+  inst/htmlwidgets/igvShiny.js
+  R
+  inst/demos
+  vignettes
+)
+
+# Placeholder and unreachable-by-design hosts used in documentation examples.
+placeholder_re='^https?://(example\.org|127\.0\.0\.1|localhost|a\.bed|b\.bed|\.\.\.)'
+
+# Assembled at run time from a base URL plus a file name, so the scrape below
+# only ever sees the directory half. Listed in full because these are the files
+# the demos actually fetch.
+composed_urls=(
+  https://gladki.pl/igvr/testFiles/sarsGenome/Sars_cov_2.ASM985889v3.dna.toplevel.fa
+  https://gladki.pl/igvr/testFiles/sarsGenome/Sars_cov_2.ASM985889v3.dna.toplevel.fa.fai
+  https://gladki.pl/igvr/testFiles/sarsGenome/Sars_cov_2.ASM985889v3.101.gff3
+  https://1000genomes.s3.amazonaws.com/phase3/data/HG02450/alignment/HG02450.mapped.ILLUMINA.bwa.ACB.low_coverage.20120522.bam
+  https://1000genomes.s3.amazonaws.com/phase3/data/HG02450/alignment/HG02450.mapped.ILLUMINA.bwa.ACB.low_coverage.20120522.bam.bai
+  https://s3.amazonaws.com/1000genomes/1000G_2504_high_coverage/additional_698_related/data/ERR3989250/HG04160.final.cram
+  https://s3.amazonaws.com/1000genomes/1000G_2504_high_coverage/additional_698_related/data/ERR3989250/HG04160.final.cram.crai
+)
+
+# Read into an array without mapfile — macOS still ships bash 3.2.
+urls=()
+while IFS= read -r url; do
+  urls+=("$url")
+done < <(
+  {
+    grep -rhoE 'https?://[^"'"'"'`) ,]+' "${sources[@]}" 2>/dev/null |
+      sed -E 's/[.,;:)]+$//' |
+      grep -vE "$placeholder_re" |
+      grep -vE '^https?://[^/]*%[ds]' |
+      # Keep only URLs whose last segment looks like a file. Bare directories
+      # (CRAN mirrors, S3 prefixes, base URLs) answer 403/404 by design and
+      # would report as permanent failures; the files under them are covered by
+      # composed_urls above.
+      grep -E '^https?://[^/]+/' |
+      grep -E '/[^/]+\.[A-Za-z0-9]+$'
+    printf '%s\n' "${composed_urls[@]}"
+  } | sort -u
+)
+
+if [[ ${#urls[@]} -eq 0 ]]; then
+  echo "No URLs found — the scrape is broken, not the assets." >&2
+  exit 1
+fi
+
+failed=()
+
+check_url() {
+  local url="$1" code
+  # HEAD first; some static hosts answer it with 403/405, so fall back to a
+  # single-byte ranged GET before calling the asset dead.
+  code=$(curl -sSL --max-time 30 -o /dev/null -w '%{http_code}' -I "$url" 2>/dev/null)
+  if [[ "$code" =~ ^2 ]]; then
+    echo "$code"
+    return 0
+  fi
+  code=$(curl -sSL --max-time 30 -o /dev/null -w '%{http_code}' -r 0-0 "$url" 2>/dev/null)
+  echo "$code"
+  [[ "$code" =~ ^2 ]]
+}
+
+printf 'Checking %d external asset URLs\n\n' "${#urls[@]}"
+
+for url in "${urls[@]}"; do
+  if code=$(check_url "$url"); then
+    printf '  ok   %-6s %s\n' "$code" "$url"
+  else
+    printf '  FAIL %-6s %s\n' "${code:-000}" "$url"
+    failed+=("${code:-000}|$url")
+  fi
+done
+
+echo
+if [[ ${#failed[@]} -eq 0 ]]; then
+  printf 'All %d URLs reachable.\n' "${#urls[@]}"
+  exit 0
+fi
+
+printf '%d of %d URLs unreachable.\n' "${#failed[@]}" "${#urls[@]}"
+
+if $markdown; then
+  {
+    echo "| HTTP | URL |"
+    echo "|------|-----|"
+    for entry in "${failed[@]}"; do
+      printf '| `%s` | %s |\n' "${entry%%|*}" "${entry#*|}"
+    done
+  } >"${ASSET_REPORT:-asset-url-report.md}"
+fi
+
+exit 1

--- a/.github/scripts/check-asset-urls.sh
+++ b/.github/scripts/check-asset-urls.sh
@@ -15,8 +15,8 @@
 
 set -uo pipefail
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-cd "$repo_root"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)" || exit 1
+cd "$repo_root" || exit 1
 
 markdown=false
 [[ "${1:-}" == "--markdown" ]] && markdown=true
@@ -41,6 +41,9 @@ composed_urls=(
   https://gladki.pl/igvr/testFiles/sarsGenome/Sars_cov_2.ASM985889v3.dna.toplevel.fa
   https://gladki.pl/igvr/testFiles/sarsGenome/Sars_cov_2.ASM985889v3.dna.toplevel.fa.fai
   https://gladki.pl/igvr/testFiles/sarsGenome/Sars_cov_2.ASM985889v3.101.gff3
+  https://gladki.pl/igvr/testFiles/ribosomal-RNA-gene.fasta
+  https://gladki.pl/igvr/testFiles/ribosomal-RNA-gene.fasta.fai
+  https://gladki.pl/igvr/testFiles/ribosomal-RNA-gene.gff3
   https://1000genomes.s3.amazonaws.com/phase3/data/HG02450/alignment/HG02450.mapped.ILLUMINA.bwa.ACB.low_coverage.20120522.bam
   https://1000genomes.s3.amazonaws.com/phase3/data/HG02450/alignment/HG02450.mapped.ILLUMINA.bwa.ACB.low_coverage.20120522.bam.bai
   https://s3.amazonaws.com/1000genomes/1000G_2504_high_coverage/additional_698_related/data/ERR3989250/HG04160.final.cram

--- a/.github/workflows/asset-url-check.yml
+++ b/.github/workflows/asset-url-check.yml
@@ -1,0 +1,70 @@
+name: asset-url-check
+
+# The genomes, fasta indices and demo tracks igvShiny points at live on hosts we
+# do not control. When one disappears the test suite stays green — it serves its
+# fixtures locally on purpose — and the breakage only surfaces as a user bug
+# report (#107). Check the real URLs on a schedule instead. See issue #115.
+
+on:
+  schedule:
+    # Mondays, 06:17 UTC. Off the hour so we are not queued with everyone else.
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+  push:
+    paths:
+      - ".github/workflows/asset-url-check.yml"
+      - ".github/scripts/check-asset-urls.sh"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check external asset URLs
+        id: check
+        env:
+          ASSET_REPORT: ${{ runner.temp }}/asset-url-report.md
+        run: |
+          set +e
+          .github/scripts/check-asset-urls.sh --markdown | tee "${{ runner.temp }}/asset-url-log.txt"
+          status=${PIPESTATUS[0]}
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          {
+            echo "## External asset URLs"
+            echo
+            echo '```'
+            cat "${{ runner.temp }}/asset-url-log.txt"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+
+      # Only the scheduled run files issues. A push that edits the checker
+      # itself should fail loudly in the log without opening a ticket.
+      - name: Report unreachable assets
+        if: steps.check.outputs.status != '0' && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPORT: ${{ runner.temp }}/asset-url-report.md
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TITLE: "Broken external asset URLs"
+        run: |
+          body=$(
+            printf 'The scheduled asset check found URLs the package points at that no longer resolve.\n\n'
+            cat "$REPORT"
+            printf '\nRun: %s\n\nRe-run locally with `.github/scripts/check-asset-urls.sh`.\n' "$RUN_URL"
+          )
+          existing=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$TITLE" --body "$body"
+          fi
+
+      - name: Fail the job when assets are unreachable
+        if: steps.check.outputs.status != '0'
+        run: exit 1

--- a/.github/workflows/asset-url-check.yml
+++ b/.github/workflows/asset-url-check.yml
@@ -14,16 +14,31 @@ on:
     paths:
       - ".github/workflows/asset-url-check.yml"
       - ".github/scripts/check-asset-urls.sh"
+  # A PR that adds or edits a URL should learn it is dead before merge, not on
+  # the following Monday.
+  pull_request:
+    paths:
+      - ".github/workflows/asset-url-check.yml"
+      - ".github/scripts/check-asset-urls.sh"
+      - "R/**"
+      - "inst/demos/**"
+      - "inst/htmlwidgets/igvShiny.js"
+      - "vignettes/**"
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Needed only by the reporting step below, which runs on the schedule.
+      issues: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Check external asset URLs
         id: check
@@ -60,11 +75,14 @@ jobs:
           )
           existing=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number')
           if [ -n "$existing" ]; then
-            gh issue comment "$existing" --body "$body"
+            echo "Issue #$existing is already open for this; not commenting again."
           else
             gh issue create --title "$TITLE" --body "$body"
           fi
 
+      # Pull requests get the table in the job summary but stay green: assets
+      # already dead before the PR was opened are not that PR's problem, and a
+      # check that is red for everyone is a check nobody reads.
       - name: Fail the job when assets are unreachable
-        if: steps.check.outputs.status != '0'
+        if: steps.check.outputs.status != '0' && github.event_name != 'pull_request'
         run: exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,3 +15,12 @@ This is an R package for **Bioconductor**. All code changes must adhere to Bioco
    As an `htmlwidgets` package, the JavaScript code is typically located in `inst/htmlwidgets/` or a similarly configured directory. Ensure any JS modifications are properly synchronized with the R widget bindings.
 6. **General Make Targets**:
    The `makefile` provides useful targets: `make roxy` (document), `make test` (run testthat tests), `make demo` (run the shiny demo app), and `make all`.
+
+## Automated review — what it does and does not catch
+
+Pull requests are reviewed by **CodeRabbit** (`.coderabbit.yaml`, profile `assertive`). Treat it as editorial review: style, obvious logic slips, missing tests and docs. It reads the diff, so it cannot catch the class of bug that has actually hurt this package — the semantics of the bundled `igv.js`. Finding those means reading `inst/htmlwidgets/lib/igv-*.js` directly, and that path is filtered out of review on purpose (~8.7 MB of third-party code).
+
+Two conventions exist for the bot's benefit:
+
+- PRs use `Related: #NNN`, not `Fixes #NNN` — see `.github/pull_request_template.md`. Auto-closing has hidden partly-finished work before (#36), but the reference still has to be there or CodeRabbit's linked-issue checks silently skip.
+- Broken external assets are checked deterministically, not by an AI reviewer: `.github/workflows/asset-url-check.yml` runs `.github/scripts/check-asset-urls.sh` weekly and files an issue when a genome, index or demo track URL stops resolving. Run the script by hand after touching any URL in `R/`, `inst/demos/` or `inst/htmlwidgets/igvShiny.js`.


### PR DESCRIPTION
Related: #115

## What changed

Automated review changed underneath us when Gemini Code Assist shut down (2026-07-17); CodeRabbit took over running on `defaults` / `CHILL`. This configures it, and hands the one job a diff-scoped reviewer structurally cannot do to a deterministic script.

- **`.coderabbit.yaml`** — profile `assertive`; `inst/htmlwidgets/lib/**`, `man/**` and `NAMESPACE` filtered out of review (8.7 MB of vendored igv.js is not ours to review); `path_instructions` carrying what a diff cannot show: the R↔JS allowlist bridge (`.sanitizeAndMergeOptions()` / `mergeExtraParameters()`), the igv.js version pinned in `igvShiny.yaml`, the local `httpuv` fixtures, and the gDRstyle NEWS linter rules.
- **`.github/pull_request_template.md`** — a `Related: #NNN` field. We avoid `Fixes #NNN` deliberately (auto-closing hid unfinished work in #36), which silently skipped CodeRabbit's linked-issue and out-of-scope checks on #114. This restores them without the auto-close.
- **`.github/scripts/check-asset-urls.sh` + `.github/workflows/asset-url-check.yml`** — weekly HEAD-request over every external genome, index and demo track URL the package points at; opens or comments on a single tracking issue when one dies. URLs are scraped from `R/`, `inst/demos/`, `vignettes/` and `inst/htmlwidgets/igvShiny.js` rather than listed, so the check cannot drift from what the code actually requests; only run-time-composed URLs (base + filename via `sprintf`) are enumerated.
- **`AGENTS.md`** — a short section on what automated review is expected to catch and what it is not.

## Why a script rather than a smarter bot

The bug that mattered on #114 — the workaround dropping the genome's Refseq track and cytoband — needed someone to read the vendored `igv-2.13.1.js` and know how `expandReference()` behaves. No diff-scoped reviewer reads an 8.7 MB library. Equally, #107 was upstream URLs starting to 404: the test suite serves its fixtures locally on purpose, so it stayed green and the breakage reached us as a user bug report. That class of failure wants a HEAD request on a cron, not an LLM.

## How it was verified

Script run locally against master — **9 of 36 URLs are already dead**, three separate causes:

| HTTP | URL |
|------|-----|
| `404` | `gladki.pl/igvr/static/tair10/…` (fasta, `.fai`, gff3, chromosomeAliases — 4 files) |
| `404` | `gladki.pl/igvr/static/rhos/…genomic.fna`, `…genomic.gff.gz` (the `.fna.fai` survives) |
| `403` | `s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/gencode.v18.collapsed.bed(.idx)` |
| `404` | `s3.amazonaws.com/igv.org.demo/gwas_sample.tsv.gz` (the `gladki.pl/igvShiny/` mirror still answers) |

Base URLs and documentation placeholders (`example.org`, S3 prefixes, CRAN mirrors) are filtered out, so those failures are all real assets the code fetches. Also noticed while scraping: three demos still set `CRAN="https://cran.microsoft.com"` — MRAN was retired in 2023; left alone here, it belongs with the demo cleanup in M4.

No R code, `NAMESPACE`, `man/` or version change — infrastructure only, so `NEWS.md` is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added automated monitoring for unreachable external asset URLs, producing a report and filing an issue on failures (with weekly scheduling and CI coverage).
  - Updated build settings to exclude internal review configuration from R package builds.

- **Documentation**
  - Expanded guidance on automated review coverage and how to run asset URL checks when relevant files change.
  - Improved pull request template sections for clearer “What changed”, “How it was verified”, and related-issue linking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->