### PR TITLE
ci: require the macOS and Windows jobs to pass (M3)

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -56,11 +56,10 @@ jobs:
       matrix:
         config:
           - { os: ubuntu-latest, r: '4.5', bioc: 'devel', cont: "bioconductor/bioconductor_docker:devel", rspm: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest" }
-          - { os: macOS-latest, r: '4.6', bioc: 'devel', allow-failure: true}
-          - { os: windows-latest, r: '4.6', bioc: 'devel', allow-failure: true}
+          - { os: macOS-latest, r: '4.6', bioc: 'devel' }
+          - { os: windows-latest, r: '4.6', bioc: 'devel' }
           ## Check https://github.com/r-lib/actions/tree/master/examples
           ## for examples using the http-user-agent
-    continue-on-error: ${{ matrix.config.allow-failure == true }}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.16
+Version: 1.9.17
 Date: 2026-07-25
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## igvShiny 1.9.17
+* Enforce green CI on macOS and Windows by dropping the allow-failure matrix flags
+
 ## igvShiny 1.9.16
 * Add a getting-started vignette covering the widget, track loaders, navigation and modules
 


### PR DESCRIPTION
## What

Removes `allow-failure: true` from the macOS and Windows matrix entries in `check-bioc.yml`, along with the now-unused `continue-on-error` expression. Both jobs are now required.

## Why

The flags date back to when mac/win failures were read as `shinytest2` flakiness. They were not: `BiocManager` refused Bioc devel (3.24) on R 4.5 and died in `Set BiocVersion`, before the check ever ran. Fixed in #123 by pinning `r: '4.6'` on both.

Since then the jobs have been green and produce a full BiocCheck (`0 ERROR / 0 WARNING / 2 NOTES`) on all three OS. The last 12 consecutive `check-bioc` runs (2026-07-25, 6 distinct SHAs, both `push` and `pull_request`) succeeded across the whole matrix.

M3 asks for CI green on Linux, macOS and Windows. With `allow-failure` in place that was reported, not enforced — a red mac/win job could not block a merge. This closes that gap.

## Effect

A macOS or Windows failure now blocks the merge. Known non-code failure modes to expect: bioconductor.org outages (`Set BiocVersion` → `bfcadd() failed`), which hit the whole matrix and are retried rather than worked around.

`asset-url-check` is a separate workflow and is unaffected — it stays red while the 9 known dead external URLs live.

Related: #129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the package to version 1.9.17.

* **Bug Fixes**
  * Improved reliability of continuous integration checks on macOS and Windows.

* **Documentation**
  * Added release notes describing the updated platform checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->