### PR TITLE
fix: reply to getGenomicRegion in any shiny module (#134)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.19
+Version: 1.9.20
 Date: 2026-07-25
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## igvShiny 1.9.20
+* Fix `getGenomicRegion()` in a shiny module whose id is not `igv`
+
 ## igvShiny 1.9.19
 * Reduce bioconductor.org round trips in CI and cancel superseded pull request runs
 * Disable the BiocCheck deprecation lookup, the last CI step reaching bioconductor.org

--- a/inst/htmlwidgets/igvShiny.js
+++ b/inst/htmlwidgets/igvShiny.js
@@ -67,6 +67,9 @@ HTMLWidgets.widget({
          igvshiny_log(el);
          igvshiny_log(el.id)
          var htmlContainerID = el.id;
+         // the custom message handlers below live outside this factory and never
+         // see `options`, so park the namespace on the element itself (#134)
+         el.moduleNS = options.moduleNS || "";
          igvshiny_log("fasta: " + options.fasta)
          igvshiny_log("index: " + options.fastaIndex)
          var fullOptions = genomeSpecificOptions(options.genomeName,
@@ -110,7 +113,8 @@ HTMLWidgets.widget({
                       : refFrame.chr + ":" + Math.round(refFrame.start) + "-" + Math.round(refFrame.end);
                    
                    document.getElementById(htmlContainerID).chromLocString = chromLocString;
-                   var eventName = "currentGenomicRegion." + htmlContainerID
+                   var eventNames = currentGenomicRegionEventNames(htmlContainerID);
+                   var eventName = eventNames.plain;
                    igvshiny_log("--- calling Shiny.setInputValue:");
    		   igvshiny_log("eventName: " + eventName);
                    igvshiny_log("chromLocString:        " + chromLocString);
@@ -120,7 +124,7 @@ HTMLWidgets.widget({
                    if(newRegion){
                       igvshiny_log("--- generating currentGenomicRegion event: " + chromLocString)
                       Shiny.setInputValue(eventName, chromLocString, {priority: "event"});
-                      var moduleEventName = moduleNamespace(options.moduleNS, "currentGenomicRegion.") + htmlContainerID.replace(options.moduleNS, "");
+                      var moduleEventName = eventNames.scoped;
                       if(moduleEventName != eventName){
                          igvshiny_log("moduleEventName: " + moduleEventName);
                          Shiny.setInputValue(moduleEventName, chromLocString, {priority: "event"});
@@ -153,6 +157,20 @@ HTMLWidgets.widget({
 function moduleNamespace(ns, nameEvent)
 {
   return(ns + nameEvent)
+}
+//------------------------------------------------------------------------------------------------------------
+// the region is announced from two places - the locuschange listener and the
+// getGenomicRegion handler - and they used to build the module-scoped name
+// differently, so a module named anything but "igv" never received the reply
+// (#134). Build both names here so the two paths cannot drift again.
+function currentGenomicRegionEventNames(elementID)
+{
+  var el = document.getElementById(elementID);
+  var ns = (el && el.moduleNS) ? el.moduleNS : "";
+  return {
+     plain: "currentGenomicRegion." + elementID,
+     scoped: moduleNamespace(ns, "currentGenomicRegion.") + elementID.replace(ns, "")
+     }
 }
 //------------------------------------------------------------------------------------------------------------
 function genomeSpecificOptions(genomeName, stockGenome, dataMode, initialLocus, displayMode, trackHeight,
@@ -401,14 +419,15 @@ Shiny.addCustomMessageHandler("getGenomicRegion",
        var elementID = message.elementID;
        var currentValue = document.getElementById(elementID).chromLocString;
        igvshiny_log("current chromLocString: " + currentValue)
-       var eventName = "currentGenomicRegion." + elementID;
+       var eventNames = currentGenomicRegionEventNames(elementID);
        igvshiny_log("--- calling Shiny.setInputValue:");
-       igvshiny_log("eventName: " + eventName);
+       igvshiny_log("eventName: " + eventNames.plain);
        igvshiny_log("chromLocString: " + currentValue)
-       Shiny.setInputValue(eventName, currentValue, {priority: "event"});
-       var moduleEventName = "igv-currentGenomicRegion." + elementID.replace("igv-", "");
-       igvshiny_log("moduleEventName: " + moduleEventName);
-       Shiny.setInputValue(moduleEventName, currentValue, {priority: "event"});
+       Shiny.setInputValue(eventNames.plain, currentValue, {priority: "event"});
+       if(eventNames.scoped != eventNames.plain){
+          igvshiny_log("moduleEventName: " + eventNames.scoped);
+          Shiny.setInputValue(eventNames.scoped, currentValue, {priority: "event"});
+          }
        })
 
 //------------------------------------------------------------------------------------------------------------------------

--- a/tests/testthat/helper-local-server.R
+++ b/tests/testthat/helper-local-server.R
@@ -13,7 +13,14 @@ local_server_start <- function() {
   port <- httpuv::randomPort()
   server <- httpuv::startServer(
     "127.0.0.1", port,
-    list(staticPaths = list("/" = dir))
+    # the R-side checks (httr::HEAD) do not care about CORS, but a browser
+    # test does: the shiny app and this server sit on different ports, so
+    # igv.js fetching a genome from here is a cross-origin request and is
+    # refused without this header - silently, as a promise that never settles
+    list(staticPaths = list("/" = httpuv::staticPath(
+      dir,
+      headers = list("Access-Control-Allow-Origin" = "*")
+    )))
   )
   list(server = server, port = port)
 }

--- a/tests/testthat/test-shinyApp.R
+++ b/tests/testthat/test-shinyApp.R
@@ -102,3 +102,91 @@ test_that("igvShinyDemo-GFF3 loads tracks correctly", {
 
     app$stop()
 })
+
+test_that("getGenomicRegion replies to a module named anything but 'igv'", {
+    # #134: the reply event name was built as
+    # "igv-currentGenomicRegion." + elementID.replace("igv-", ""), so only a
+    # module whose id happened to be "igv" (as every demo uses) received it.
+    # The app below names the module "browser" and fails on the old JS.
+    options(chromote.timeout = 120)
+
+    port <- local_server()
+    app_file <- tempfile(fileext = ".R")
+    writeLines(sprintf('
+        library(shiny)
+        library(igvShiny)
+
+        igvUI <- function(id) {
+            ns <- NS(id)
+            fluidPage(
+                actionButton(ns("getRegionButton"), "Get Region"),
+                verbatimTextOutput(ns("regionDisplay")),
+                igvShinyOutput(ns("igvShiny_0"))
+            )
+        }
+
+        igvServer <- function(id) {
+            moduleServer(id, function(input, output, session) {
+                ns <- session$ns
+                output$igvShiny_0 <- renderIgvShiny({
+                    igvShiny(parseAndValidateGenomeSpec(
+                        genomeName = "ribo",
+                        initialLocus = "all",
+                        stockGenome = FALSE,
+                        dataMode = "http",
+                        fasta = "%s",
+                        fastaIndex = "%s",
+                        genomeAnnotation = "%s"
+                    ))
+                })
+                observeEvent(input$getRegionButton, {
+                    getGenomicRegion(session, id = ns("igvShiny_0"))
+                })
+                observeEvent(input[["currentGenomicRegion.igvShiny_0"]], {
+                    output$regionDisplay <- renderText({
+                        input[["currentGenomicRegion.igvShiny_0"]]
+                    })
+                })
+            })
+        }
+
+        shinyApp(
+            ui = fluidPage(igvUI("browser")),
+            server = function(input, output, session) igvServer("browser")
+        )',
+        local_url(port, "ribosomal-RNA-gene.fasta"),
+        local_url(port, "ribosomal-RNA-gene.fasta.fai"),
+        local_url(port, "ribosomal-RNA-gene.gff3")
+    ), app_file)
+
+    app <- AppDriver$new(
+        app_dir = shiny::shinyAppFile(app_file),
+        name = "igv-shiny-module-region",
+        height = 695,
+        width = 1235,
+        load_timeout = 1e+6,
+        timeout = 1e+6
+    )
+    app$wait_for_value(input = "igvReady")
+    Sys.sleep(2)
+
+    app$click("browser-getRegionButton")
+
+    # the reply travels browser -> shiny as an input event, so poll rather than
+    # read once; an empty display after the deadline is the #134 failure
+    deadline <- Sys.time() + 30
+    region <- ""
+    repeat {
+        region <- app$get_value(output = "browser-regionDisplay")
+        if (!is.null(region) && nzchar(region)) {
+            break
+        }
+        if (Sys.time() > deadline) {
+            break
+        }
+        Sys.sleep(0.5)
+    }
+    expect_equal(region, "all")
+
+    app$stop()
+})


### PR DESCRIPTION
Fixes the bug found while writing the getting-started vignette (#135).

## The bug

The `getGenomicRegion` message handler built the module-scoped reply as:

```js
var moduleEventName = "igv-currentGenomicRegion." + elementID.replace("igv-", "");
```

That hardcodes a namespace. It works only when the module id is literally `"igv"`, which is what `igvShinyDemo-withModules.R` uses — so the demo never showed it. With any other id, e.g. `moduleServer("browser", …)`, the reply is sent as `igv-currentGenomicRegion.browser-igvShiny_0`, a name nothing listens to, and `getGenomicRegion()` silently returns nothing.

Pan and zoom were never affected: the `locuschange` listener builds the same name correctly from `options.moduleNS`. Only the explicit "where am I" query was lost.

## The fix

The message handlers are registered at file scope, outside the widget factory, so they never see the render `options` — only `message.elementID`. The namespace is therefore parked on the container element during `renderValue`, beside the existing `.chromLocString`, and both call sites now derive names from one helper:

```js
function currentGenomicRegionEventNames(elementID)
```

Two copies of this naming logic are what allowed the paths to drift apart, so this removes the second copy rather than patching it. When there is no module the scoped name equals the plain one and the duplicate emit is skipped — previously the handler always fired a bogus `igv-…` event in non-module apps as well.

## Verification

Extracted both functions into node against a fake DOM (the approach used on #110):

| moduleNS | element id | scoped event |
|---|---|---|
| `igv-` | `igv-igvShiny_0` | `igv-currentGenomicRegion.igvShiny_0` (unchanged — the demo) |
| `browser-` | `browser-igvShiny_0` | `browser-currentGenomicRegion.igvShiny_0` |
| `myModule-` | `myModule-igv` | `myModule-currentGenomicRegion.igv` |
| *(none)* | `igvShiny_0` | equals the plain name, no second emit |

Plus an element with no namespace and a missing element — both fall back to the non-module name rather than throwing.

End to end, with the same app on both versions of the JS:

| | `igvReady` | module's `regionDisplay` |
|---|---|---|
| before | TRUE | **NULL** |
| after | TRUE | `U13369.1:7,276-8,225` |

New `test-shinyApp.R` case builds a module named `browser` and asserts the region comes back. Local run: `FAIL 0 | PASS 7 | SKIP 1`.

## One thing worth flagging

The test app serves its custom genome from the `httpuv` fixture server added in #129, which now sends `Access-Control-Allow-Origin: *`. That server is on a different port from the shiny app, so to a browser it is a different origin. Without the header igv.js cannot fetch the genome and `igv.createBrowser` returns a promise that **never settles** — no console error, no rejection, the app just never reaches `igvReady`. The R-side tests never noticed because `httr::HEAD` does not do CORS; this is the first browser test to use that server.

Worth remembering next to the other igv.js failure signatures: `status: 404` = wrong path on our side, `status: 0` = the browser refused the fetch, promise that never returns = missing CORS header.

Version bumped to 1.9.18 assuming #136 lands first; happy to rebase if not.

Related: #134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `getGenomicRegion()` and genomic region updates when `igvShinyOutput` is used inside Shiny modules with IDs other than `igv`.
  * Updated event-name handling to ensure module-scoped events are correctly emitted and processed.
* **Tests**
  * Added an integration test reproducing the non-`igv` module failure for `getGenomicRegion()`.
  * Improved the local test server to serve fixture assets safely and allow cross-origin requests.
* **Documentation**
  * Added release notes for version 1.9.20.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->