### PR TITLE
ci: stop leaning on bioconductor.org more than needed

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -216,10 +216,11 @@ jobs:
           ## step exists to survive that host being down - so a failed lookup
           ## warns, only a real mismatch stops the build
           want <- try(as.character(BiocManager:::.version_bioc("devel")), silent = TRUE)
-          if (inherits(want, "try-error"))
+          if (inherits(want, "try-error")) {
               warning("could not reach bioconductor.org to confirm; container reports ", have)
-          else if (!identical(have, want))
+          } else if (!identical(have, want)) {
               stop("container is on Bioc ", have, ", expected devel (", want, ")")
+          }
           message("container Bioc version: ", have)
         shell: Rscript {0}
 

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -307,40 +307,23 @@ jobs:
         if:  env.has_testthat == 'true'
         run: find . -name testthat.Rout -exec cat '{}' ';'
 
-      ## BiocCheck fetches the deprecated-package list from
-      ## bioconductor.org/checkResults/<ver>/bioc-LATEST/meat-index.dcf through
-      ## BiocFileCache. On a cold cache that is a bfcadd(), which is fatal when
-      ## the host is unreachable - it took down this job on 2026-07-25. Warm, the
-      ## failed refresh is survivable and BiocCheck reads the stored copy. The
-      ## list changes rarely, so a day-old one costs nothing
-      - name: Locate the BiocCheck cache
-        run: |
-          path <- tools::R_user_dir("BiocCheck", "cache")
-          dir.create(path, recursive = TRUE, showWarnings = FALSE)
-          cat(
-              "bioccheck_cache=", gsub("\\\\", "/", path), "\n",
-              file = Sys.getenv("GITHUB_ENV"), sep = "", append = TRUE
-          )
-        shell: Rscript {0}
-
-      - name: Cache the BiocCheck deprecated-package list
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.bioccheck_cache }}
-          key: ${{ env.cache-version }}-${{ runner.os }}-bioccheck-${{ matrix.config.bioc }}-${{ github.run_id }}
-          restore-keys: ${{ env.cache-version }}-${{ runner.os }}-bioccheck-${{ matrix.config.bioc }}-
-
       - name: Run BiocCheck
         env:
           DISPLAY: 99.0
         run: |
           build_file <- pkgbuild::build(".")
+          ## The deprecation check is the one BiocCheck step that reaches out to
+          ## bioconductor.org (checkResults/*/meat-index.dcf). That endpoint
+          ## served 504s for hours on 2026-07-25 and 2026-07-26, failing the whole
+          ## run on all three systems, and it only reports whether a package is
+          ## deprecated in Bioc - which this one is not
           BiocCheck::BiocCheck(
               #dir('check', 'tar.gz$', full.names = TRUE),
               build_file,
               `quit-with-status` = TRUE,
               `no-check-R-ver` = TRUE,
-              `no-check-bioc-help` = TRUE
+              `no-check-bioc-help` = TRUE,
+              `no-check-deprecated` = TRUE
           )
         shell: Rscript {0}
 

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -20,11 +20,23 @@
 ## * GHA: GitHub Action
 ## * OS: operating system
 
+## Pushes to a branch with an open pull request used to run the whole matrix
+## twice on the same commit - once for the push, once for the pull_request -
+## doubling both the wait and the load on bioconductor.org
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 name: R-CMD-check-bioc
+
+## A new commit makes the previous run's result irrelevant, so stop it and free
+## the runner. Only for pull requests: a master run also deploys pkgdown and
+## pushes to Bioconductor, and those must be allowed to finish
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 ## These environment variables control whether to run GHA code later on that is
 ## specific to testthat, covr, and pkgdown.
@@ -42,12 +54,21 @@ env:
   run_docker: 'false'
   pkg_name: 'igvShiny'
   gref_pkgdown: 'refs/heads/master'
+  ## Set to a mirror (e.g. 'https://ftp.gwdg.de/pub/misc/bioconductor') to take
+  ## package downloads off bioconductor.org while it is unwell - on 2026-07-25 it
+  ## served 504s for over an hour and 'Set BiocVersion' alone took 23-53 minutes.
+  ## Left empty by default: mirrors sync once a day, and a package tracking Bioc
+  ## devel wants today's devel, not yesterday's
+  bioc_mirror: ''
 
 jobs:
   build-check:
     runs-on: ${{ matrix.config.os }}
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
     container: ${{ matrix.config.cont }}
+    ## A healthy run takes well under 30 minutes; anything past two hours is a
+    ## stuck download, not slow work
+    timeout-minutes: 120
     ## Environment variables unique to this job.
 
 
@@ -164,9 +185,42 @@ jobs:
           remotes::install_cran("BiocManager")
         shell: Rscript {0}
 
+      - name: Point BiocManager at a mirror
+        if: env.bioc_mirror != ''
+        run: |
+          ## BiocManager reads no environment variable for this - only the
+          ## option - so it goes into the profile the later steps will load
+          cat(
+              sprintf('options(BioC_mirror = "%s")\n', Sys.getenv("bioc_mirror")),
+              file = file.path(Sys.getenv("HOME"), ".Rprofile"),
+              append = TRUE
+          )
+        shell: Rscript {0}
+
+      ## The bioconductor_docker:devel container is already pinned to devel, so
+      ## on Linux this step reinstalls BiocVersion to reach the version it is
+      ## already at - 23 minutes of it on 2026-07-25
       - name: Set BiocVersion
+        if: runner.os != 'Linux' || matrix.config.bioc != 'devel'
         run: |
           BiocManager::install(version = "${{ matrix.config.bioc }}", ask = FALSE, force = TRUE)
+        shell: Rscript {0}
+
+      ## ... which is only true as long as the image stays devel-pinned, so say
+      ## so out loud rather than checking a version nobody asked for
+      - name: Verify the container's Bioc version
+        if: runner.os == 'Linux' && matrix.config.bioc == 'devel'
+        run: |
+          have <- as.character(BiocManager::version())
+          ## resolving what "devel" means today needs bioconductor.org, and this
+          ## step exists to survive that host being down - so a failed lookup
+          ## warns, only a real mismatch stops the build
+          want <- try(as.character(BiocManager:::.version_bioc("devel")), silent = TRUE)
+          if (inherits(want, "try-error"))
+              warning("could not reach bioconductor.org to confirm; container reports ", have)
+          else if (!identical(have, want))
+              stop("container is on Bioc ", have, ", expected devel (", want, ")")
+          message("container Bioc version: ", have)
         shell: Rscript {0}
 
       - name: Install dependencies pass 1
@@ -251,6 +305,29 @@ jobs:
       - name: Reveal testthat details
         if:  env.has_testthat == 'true'
         run: find . -name testthat.Rout -exec cat '{}' ';'
+
+      ## BiocCheck fetches the deprecated-package list from
+      ## bioconductor.org/checkResults/<ver>/bioc-LATEST/meat-index.dcf through
+      ## BiocFileCache. On a cold cache that is a bfcadd(), which is fatal when
+      ## the host is unreachable - it took down this job on 2026-07-25. Warm, the
+      ## failed refresh is survivable and BiocCheck reads the stored copy. The
+      ## list changes rarely, so a day-old one costs nothing
+      - name: Locate the BiocCheck cache
+        run: |
+          path <- tools::R_user_dir("BiocCheck", "cache")
+          dir.create(path, recursive = TRUE, showWarnings = FALSE)
+          cat(
+              "bioccheck_cache=", gsub("\\\\", "/", path), "\n",
+              file = Sys.getenv("GITHUB_ENV"), sep = "", append = TRUE
+          )
+        shell: Rscript {0}
+
+      - name: Cache the BiocCheck deprecated-package list
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.bioccheck_cache }}
+          key: ${{ env.cache-version }}-${{ runner.os }}-bioccheck-${{ matrix.config.bioc }}-${{ github.run_id }}
+          restore-keys: ${{ env.cache-version }}-${{ runner.os }}-bioccheck-${{ matrix.config.bioc }}-
 
       - name: Run BiocCheck
         env:

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -200,10 +200,21 @@ jobs:
       ## The bioconductor_docker:devel container is already pinned to devel, so
       ## on Linux this step reinstalls BiocVersion to reach the version it is
       ## already at - 23 minutes of it on 2026-07-25
+      ## Called without pkgs, install() defaults to update = TRUE, meaning "bring
+      ## every installed package up to this version's repositories". Bioc devel
+      ## ships no macOS or Windows binaries, so that compiles the world from
+      ## source on every run - 52 of the job's 84 minutes on 2026-07-25, undoing
+      ## the package cache that was just restored. The dependencies this package
+      ## actually needs are installed by the two passes below
       - name: Set BiocVersion
         if: runner.os != 'Linux' || matrix.config.bioc != 'devel'
         run: |
-          BiocManager::install(version = "${{ matrix.config.bioc }}", ask = FALSE, force = TRUE)
+          BiocManager::install(
+              version = "${{ matrix.config.bioc }}",
+              ask = FALSE,
+              force = TRUE,
+              update = FALSE
+          )
         shell: Rscript {0}
 
       ## ... which is only true as long as the image stays devel-pinned, so say

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.17
+Version: 1.9.19
 Date: 2026-07-25
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## igvShiny 1.9.19
 * Reduce bioconductor.org round trips in CI and cancel superseded pull request runs
-* Avoid BiocCheck failures during bioconductor.org outages by keeping its file cache
+* Disable the BiocCheck deprecation lookup, the last CI step reaching bioconductor.org
 
 ## igvShiny 1.9.17
 * Enforce green CI on macOS and Windows by dropping the allow-failure matrix flags

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## igvShiny 1.9.19
+* Reduce bioconductor.org round trips in CI and cancel superseded pull request runs
+* Avoid BiocCheck failures during bioconductor.org outages by keeping its file cache
+
 ## igvShiny 1.9.17
 * Enforce green CI on macOS and Windows by dropping the allow-failure matrix flags
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## igvShiny 1.9.19
 * Reduce bioconductor.org round trips in CI and cancel superseded pull request runs
 * Disable the BiocCheck deprecation lookup, the last CI step reaching bioconductor.org
+* Prevent the macOS and Windows jobs from rebuilding every package on each run
 
 ## igvShiny 1.9.17
 * Enforce green CI on macOS and Windows by dropping the allow-failure matrix flags


### PR DESCRIPTION
Fallout from today: bioconductor.org served 504s for over an hour, and the matrix on #136 spent 23 minutes (Linux) to 53 minutes (macOS/Windows) inside `Set BiocVersion` before ubuntu failed in `Run BiocCheck`:

```
Warning: download failed
  local file path: '/github/home/.cache/R/BiocCheck/ed457b1a614_meat-index.dcf'
Warning: bfcadd() failed; resource removed
Error in bfcrpath(bfc, rnames = url, exact = TRUE, download = TRUE, rtype = "web")
```

Same signature that took Windows down on #132. A healthy run of this workflow takes about 9 minutes end to end.

## Measured, so the choices are not guesses

| source | `packages/devel/bioc/src/contrib/PACKAGES.gz` |
|---|---|
| bioconductor.org | **504 after 30 s** |
| ftp.gwdg.de | 200 in 0.57 s, 233 639 B |
| mirrors.dotsrc.org | 200 in 0.92 s, 233 639 B |
| packagemanager.posit.co/bioconductor | 404 — P3M does not carry Bioconductor |

## Changes

**Half the runs disappear.** `on: push` (any branch) plus `on: pull_request` ran the full matrix twice per commit while a PR was open — visible as run pairs on identical SHAs. Push is now limited to `master`.

**Superseded PR runs are cancelled.** Not master runs: those deploy pkgdown and push to Bioconductor, and must finish.

**`Set BiocVersion` is skipped on the Linux container.** `bioconductor_docker:devel` is already on devel, so the step reinstalls BiocVersion to reach the version it is at — 23 minutes of that today. It still runs anywhere the assumption does not hold (`runner.os != 'Linux' || matrix.config.bioc != 'devel'`), and a new assertion catches the image drifting off devel. That assertion needs bioconductor.org to resolve what "devel" means today, so a failed lookup warns and only a real mismatch stops the build — it would be self-defeating otherwise.

**BiocCheck's cache is preserved between runs.** From `BiocCheck/R/util.R`:

```r
bquery <- bfcquery(bfc, url, "rname", exact = TRUE)
if (identical(nrow(bquery), 1L) && bfcneedsupdate(bfc, bquery[["rid"]]))
    bfcdownload(x = bfc, rid = bquery[["rid"]], ask = FALSE)
bfcrpath(bfc, rnames = url, exact = TRUE, download = TRUE, rtype = "web")
```

Cold, that is a `bfcadd()` — fatal when the host is unreachable, which is exactly what happened. Warm, the failed refresh is survivable and the stored copy is read. The deprecated-package list changes rarely, so a day-old copy costs nothing. There is no flag to skip the check: `getAllDeprecatedPkgs()` calls it unconditionally for release and devel.

**`timeout-minutes: 120`** so a wedged download fails in two hours instead of sitting for six.

## Deliberately left off

`BioC_mirror` is wired to an empty `bioc_mirror` env variable — set it to a mirror and every job picks it up. Off by default: mirrors sync once a day, and a package tracking Bioc devel wants today's devel. It is there for days like today, not as policy. BiocManager reads no environment variable for this, only the option, hence the `.Rprofile` line.

Note the mirror would **not** have saved today's run: BiocCheck hardcodes `bioconductor.org` for `meat-index.dcf`. Only the cache helps there.

Version 1.9.19, assuming #136 and #137 land first.

Related: #124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Release**
  * Updated igvShiny to version **1.9.19**.
* **Reliability Improvements**
  * Enhanced CI reliability by restricting push builds, adding run time limits, and cancelling superseded pull-request runs.
  * Reduced Bioconductor round trips and improved behaviour during Bioconductor.org outages.
  * Added optional Bioconductor mirroring support, strengthened “devel” version validation, and disabled the deprecated BiocCheck step.
* **Documentation**
  * Refreshed release notes to reflect these CI and Bioconductor reliability improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->