### PR TITLE
chore: bump the GitHub Actions used in CI

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -103,7 +103,7 @@ jobs:
       ## https://github.com/r-lib/actions/blob/master/examples/check-standard.yaml
       ## If they update their steps, we will also need to update ours.
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       ## R is already included in the Bioconductor docker images
       - name: Setup R from r-lib
@@ -126,7 +126,7 @@ jobs:
 
       - name: Restore R package cache
         if: "!contains(github.event.head_commit.message, '/nocache') && runner.os != 'Linux'"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ env.cache-version }}-${{ runner.os }}-biocversion-${{ matrix.config.bioc }}-r-${{ matrix.config.r }}-${{ hashFiles('.github/depends.Rds') }}
@@ -134,7 +134,7 @@ jobs:
 
       - name: Cache R packages on Linux
         if: "!contains(github.event.head_commit.message, '/nocache') && runner.os == 'Linux' "
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /home/runner/work/_temp/Library
           key: ${{ env.cache-version }}-${{ runner.os }}-biocversion-${{ matrix.config.bioc }}-r-${{ matrix.config.r }}-${{ hashFiles('.github/depends.Rds') }}
@@ -389,7 +389,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ runner.os }}-biocversion-${{ matrix.config.bioc }}-r-${{ matrix.config.r }}-results
           path: check
@@ -403,7 +403,7 @@ jobs:
     steps:
       - name: Checkout Repository
         if: "!contains(github.event.head_commit.message, '/nodocker') && env.run_docker == 'true' && github.ref == 'refs/heads/devel'"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Register repo name
         if: "!contains(github.event.head_commit.message, '/nodocker') && env.run_docker == 'true' && github.ref == 'refs/heads/devel'"
@@ -413,15 +413,15 @@ jobs:
 
       - name: Set up QEMU
         if: "!contains(github.event.head_commit.message, '/nodocker') && env.run_docker == 'true' && github.ref == 'refs/heads/devel'"
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         if: "!contains(github.event.head_commit.message, '/nodocker') && env.run_docker == 'true' && github.ref == 'refs/heads/devel'"
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
         if: "!contains(github.event.head_commit.message, '/nodocker') && env.run_docker == 'true' && github.ref == 'refs/heads/devel'"
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -435,7 +435,7 @@ jobs:
 
       - name: Build and Push Docker
         if: "!contains(github.event.head_commit.message, '/nodocker') && env.run_docker == 'true' && github.ref == 'refs/heads/devel' && success()"
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/.github/workflows/push-to-bioc.yml
+++ b/.github/workflows/push-to-bioc.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.20
+Version: 1.9.21
 Date: 2026-07-25
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## igvShiny 1.9.21
+* Bump the GitHub Actions used in CI to their current major versions
+* Replace the mutable `upload-artifact@master` reference with a released version
+
 ## igvShiny 1.9.20
 * Fix `getGenomicRegion()` in a shiny module whose id is not `igv`
 


### PR DESCRIPTION
`actions/upload-artifact` was pinned to `@master` — a moving branch rather than a release — and `checkout`/`cache` sat on v3, which GitHub is winding down. The v3 cache runner already prints `too old to run on GitHub Actions` in our logs, and CodeRabbit flagged the same on #138.

| action | before | after |
|---|---|---|
| `actions/upload-artifact` | `@master` | `v4` |
| `actions/checkout` | `v3` (×3, one already `v4`) | `v4` |
| `actions/cache` | `v3` | `v4` |
| `docker/setup-qemu-action` | `v2` | `v3` |
| `docker/setup-buildx-action` | `v2` | `v3` |
| `docker/login-action` | `v2` | `v3` |
| `docker/build-push-action` | `v4` | `v6` |

`upload-artifact@v4` refuses to write the same artifact name twice in one run. Ours embeds `runner.os`, the Bioc release and the R version, so every matrix job writes a distinct name and the rule does not bite.

Left deliberately: no `@sha` pinning. Without Dependabot, pinned digests rot into stale versions, and these are first-party GitHub actions on a public repo.

Related: #138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Updated the package version to 1.9.21.
* **Chores**
  * Updated continuous integration workflow tooling to current supported major versions (including checkout, caching, and artifact upload steps).
  * Updated Docker build-and-push workflow action versions for the devel build path when Docker is enabled.
* **Documentation**
  * Updated release notes to mention the CI action upgrades and the artifact upload action change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->