### PR TITLE
ci: check Linux on pull requests, the full matrix on master and nightly

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -23,11 +23,24 @@
 ## Pushes to a branch with an open pull request used to run the whole matrix
 ## twice on the same commit - once for the push, once for the pull_request -
 ## doubling both the wait and the load on bioconductor.org
+## The macOS and Windows jobs spend most of their 80 minutes compiling the Bioc
+## devel dependency tree from source - devel ships no binaries for either, and it
+## moves daily, so the package cache can never fully cover it. Linux runs in the
+## Bioconductor container and finishes in a fraction of that. Pull requests
+## therefore check Linux only, and the full matrix runs where a slow answer still
+## arrives in time to matter: on master, nightly, and on any pull request carrying
+## the full-ci label
 on:
   push:
     branches:
       - master
+  ## labeled is on the list so that adding full-ci to an open pull request
+  ## starts a run - the default types fire only on open, push and reopen
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
 
 name: R-CMD-check-bioc
 
@@ -75,12 +88,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - { os: ubuntu-latest, r: '4.5', bioc: 'devel', cont: "bioconductor/bioconductor_docker:devel", rspm: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest" }
-          - { os: macOS-latest, r: '4.6', bioc: 'devel' }
-          - { os: windows-latest, r: '4.6', bioc: 'devel' }
-          ## Check https://github.com/r-lib/actions/tree/master/examples
-          ## for examples using the http-user-agent
+        ## Linux always; macOS and Windows unless this is a plain pull request.
+        ## Keep the two lists in step - the Linux entry is repeated verbatim
+        config: ${{ (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full-ci')) && fromJSON('[{"os":"ubuntu-latest","r":"4.5","bioc":"devel","cont":"bioconductor/bioconductor_docker:devel","rspm":"https://packagemanager.rstudio.com/cran/__linux__/jammy/latest"}]') || fromJSON('[{"os":"ubuntu-latest","r":"4.5","bioc":"devel","cont":"bioconductor/bioconductor_docker:devel","rspm":"https://packagemanager.rstudio.com/cran/__linux__/jammy/latest"},{"os":"macOS-latest","r":"4.6","bioc":"devel"},{"os":"windows-latest","r":"4.6","bioc":"devel"}]') }}
+        ## Check https://github.com/r-lib/actions/tree/master/examples
+        ## for examples using the http-user-agent
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.21
+Version: 1.9.22
 Date: 2026-07-25
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## igvShiny 1.9.22
+* Reduce the pull request matrix to Linux, running macOS and Windows on master and nightly
+* Enable a full-ci label to force the whole matrix on a pull request
+
 ## igvShiny 1.9.21
 * Bump the GitHub Actions used in CI to their current major versions
 * Replace the mutable `upload-artifact@master` reference with a released version


### PR DESCRIPTION
## Why

macOS and Windows take ~80 minutes per run, and almost all of it is compiling the Bioc **devel** dependency tree from source. Devel ships no binaries for either system and moves daily, so the package cache can never fully cover it. Measured on this repo, 2026-07-26, in a run that passed:

| step | macOS | windows | ubuntu |
|---|---|---|---|
| Install BiocGenerics | 24 min | 24 min | 15 min |
| Install dependencies pass 1 | 22 min | 22 min | 17 min |
| Install dependencies pass 2 | — | 8 min | 8 min |
| Query dependencies | 7 min | 7 min | 7 min |
| **Run CMD check** | **2 min** | **2 min** | **2 min** |
| **job total** | **77 min** | **77 min** | **57 min** |

The actual checking is 2 minutes. Everything else is dependency installation, repeated per run.

## What changes

- **pull requests** → Linux only, answer in ~15 minutes
- **push to master** → full matrix, so nothing reaches Bioconductor unchecked
- **nightly** (`cron: 0 3 * * *`) → full matrix
- **`full-ci` label** → full matrix on a pull request, for changes touching the JS or track loaders
- `workflow_dispatch` added, so the matrix can be run by hand

No repo settings change is needed: `Require status checks to pass before merging` is off on master, so dropping mac/win from pull requests cannot leave anything waiting on a job that never starts.

## Trade-off

A macOS or Windows regression now surfaces at merge to master rather than on the pull request. The `full-ci` label is the escape hatch when a change looks platform-sensitive.

Related: #136, #138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Release**
  - Updated igvShiny to version 1.9.22.

- **Improvements**
  - Streamlined pull request checks by running a faster Linux-only validation by default.
  - Full cross-platform checks remain available for scheduled builds, master branch updates, and pull requests marked for full validation.
  - Added the option to start validation manually and documented the full validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->