### PR TITLE
ci: check all three systems on pull requests again

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -165,7 +165,9 @@ jobs:
         run: |
           ## Enable installing XML from source if needed
           brew install libxml2
-          echo "XML_CONFIG=/usr/local/opt/libxml2/bin/xml2-config" >> $GITHUB_ENV
+          ## /usr/local/opt is the Intel Homebrew prefix; macos-latest is arm64,
+          ## where the same formula lands under /opt/homebrew
+          echo "XML_CONFIG=$(brew --prefix libxml2)/bin/xml2-config" >> $GITHUB_ENV
 
           ## Required to install magick as noted at
           ## https://github.com/r-lib/usethis/commit/f1f1e0d10c1ebc75fd4c18fa7e2de4551fd9978f#diff-9bfee71065492f63457918efcd912cf2

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -23,21 +23,15 @@
 ## Pushes to a branch with an open pull request used to run the whole matrix
 ## twice on the same commit - once for the push, once for the pull_request -
 ## doubling both the wait and the load on bioconductor.org
-## The macOS and Windows jobs spend most of their 80 minutes compiling the Bioc
-## devel dependency tree from source - devel ships no binaries for either, and it
-## moves daily, so the package cache can never fully cover it. Linux runs in the
-## Bioconductor container and finishes in a fraction of that. Pull requests
-## therefore check Linux only, and the full matrix runs where a slow answer still
-## arrives in time to matter: on master, nightly, and on any pull request carrying
-## the full-ci label
+## Every pull request checks all three systems. The 80-minute macOS and Windows
+## runs that once argued for a Linux-only pull request check were cold-cache
+## outliers: with the cache warm those jobs finish in 5-8 minutes, so there is
+## nothing left to trade away
 on:
   push:
     branches:
       - master
-  ## labeled is on the list so that adding full-ci to an open pull request
-  ## starts a run - the default types fire only on open, push and reopen
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
   schedule:
     - cron: '0 3 * * *'
   workflow_dispatch:
@@ -88,9 +82,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ## Linux always; macOS and Windows unless this is a plain pull request.
-        ## Keep the two lists in step - the Linux entry is repeated verbatim
-        config: ${{ (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full-ci')) && fromJSON('[{"os":"ubuntu-latest","r":"4.5","bioc":"devel","cont":"bioconductor/bioconductor_docker:devel","rspm":"https://packagemanager.rstudio.com/cran/__linux__/jammy/latest"}]') || fromJSON('[{"os":"ubuntu-latest","r":"4.5","bioc":"devel","cont":"bioconductor/bioconductor_docker:devel","rspm":"https://packagemanager.rstudio.com/cran/__linux__/jammy/latest"},{"os":"macOS-latest","r":"4.6","bioc":"devel"},{"os":"windows-latest","r":"4.6","bioc":"devel"}]') }}
+        config:
+          - { os: ubuntu-latest, r: '4.5', bioc: 'devel', cont: "bioconductor/bioconductor_docker:devel", rspm: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest" }
+          - { os: macOS-latest, r: '4.6', bioc: 'devel'}
+          - { os: windows-latest, r: '4.6', bioc: 'devel'}
         ## Check https://github.com/r-lib/actions/tree/master/examples
         ## for examples using the http-user-agent
     env:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.22
-Date: 2026-07-25
+Version: 1.9.23
+Date: 2026-07-27
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 
     email = "paul.thurmond.shannon@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## igvShiny 1.9.23
 * Restore the full three-system matrix on every pull request
 * Remove the full-ci label, redundant once macOS and Windows finish in minutes
+* Correct the macOS libxml2 config path, wrong since the runners moved to arm64
 
 ## igvShiny 1.9.22
 * Reduce the pull request matrix to Linux, running macOS and Windows on master and nightly

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## igvShiny 1.9.23
+* Restore the full three-system matrix on every pull request
+* Remove the full-ci label, redundant once macOS and Windows finish in minutes
+
 ## igvShiny 1.9.22
 * Reduce the pull request matrix to Linux, running macOS and Windows on master and nightly
 * Enable a full-ci label to force the whole matrix on a pull request


### PR DESCRIPTION
#140 cut pull requests down to `ubuntu-latest`, keeping macOS and Windows for master, the nightly cron and a `full-ci` label. The trade was sized against 77-80 minute macOS and Windows runs — and those numbers were cold-cache outliers, not the norm.

Warm-cache measurements from the first nightly (run [30243281490](https://github.com/gladkia/igvShiny/actions/runs/30243281490), 2026-07-27) and the post-merge push run of #140:

| job | nightly | push |
|---|---|---|
| macOS-latest | 5 min | 5 min |
| windows-latest | 8 min | 7 min |
| ubuntu-latest | 7 min | 7 min |

There is no 70 minutes to buy back, so the conditional matrix only bought a coverage gap: a pull request could break macOS or Windows and stay green until it hit master.

This restores the plain three-entry matrix and drops the `full-ci` label along with the `labeled` event type it needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qp8soQe3fbShVoyHhv58g8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release**
  - Updated igvShiny to version 1.9.23 (dated 27 July 2026).

- **Quality Improvements**
  - Pull requests now run a full validation across Linux, macOS, and Windows, strengthening cross-platform confidence.

- **CI Enhancements**
  - Corrected the macOS `libxml2` configuration to use the appropriate Apple Silicon Homebrew prefix.

- **Documentation**
  - Updated the release notes to reflect the new version and the expanded cross-platform validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->