### PR TITLE
feat: let loadGwasTrack callers map gwas columns, and show it in the demo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.24
+Version: 1.9.25
 Date: 2026-07-27
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## igvShiny 1.9.25
+* Allow a gwas column mapping through trackConfig, for loadGwasTrack callers
+* Extend the Connect Cloud demo with a gwas track using custom columns and colors
+
 ## igvShiny 1.9.24
 * Send the gwas column mapping to igv.js, so any data frame layout works (#32)
 * Support a chromosomeColorMap argument coloring gwas points per chromosome (#46)

--- a/R/igvShiny.R
+++ b/R/igvShiny.R
@@ -17,6 +17,9 @@
   "flipAxis", "stroke", "noStroke", "fill", "noFill", "featureHeight",
   "showLabels", "font", "fontSize", "fontStyle", "fontWeight", "colorTable",
   "colorByAttribute",
+  ## the gwas parser reads these 1-based; without them it guesses the layout
+  ## from the header names it knows, and any other spelling draws nothing
+  "columns",
   "showAllBases", "samplingWindowSize", "samplingDepth", "maxRows",
   "hideEmptyTracks", "oauthToken", "headers", "viewAsPairs", "pairsSupported",
   "maxPanelHeight", "separateBam", "wholeGenomeView", "roi", "queryable"
@@ -905,7 +908,11 @@ loadVcfTrack <- function(session,
 #' @param tbl.gwas data.frame, with at least "chrom" "start" "end" columns
 #' @param deleteTracksOfSameName logical, default TRUE
 #' @param trackConfig a named list of additional igv.js track configuration
-#' options.
+#' options. A table whose headers igv.js does not recognize needs its layout
+#' spelled out, 1-based, as
+#' \code{columns = list(chromosome = 3, position = 4, value = 10)};
+#' \code{colorTable} takes a chromosome-to-color map, see
+#' \code{\link{GWASTrack}}
 #'
 #' @examples
 #' library(igvShiny)

--- a/demo/posit-connect/app.R
+++ b/demo/posit-connect/app.R
@@ -90,7 +90,9 @@ ui <- page_sidebar(
         demoButton("addBedGraphTrackButton", "BedGraph", "chart-area"),
         demoButton("addBedGraphWithAltColorTrackButton", "BedGraph (AltColor)", "palette"),
         demoButton("addBed9TrackButton", "bed9", "grip-lines"),
-        demoButton("addGwasTrackButton", "GWAS", "chart-column")
+        demoButton("addGwasTrackButton", "GWAS", "chart-column"),
+        demoButton("addGwasCustomTrackButton", "GWAS (columns + colors)",
+                   "palette")
       ),
 
       accordion_panel(
@@ -180,6 +182,20 @@ server <- function(input, output, session) {
     printf("---- addGWASTrack")
     showGenomicRegion(session, id = "igvShiny_0", "chr19:45,248,108-45,564,645")
     loadGwasTrack(session, id = "igvShiny_0", trackName = "gwas", tbl = tbl.gwas, deleteTracksOfSameName = FALSE)
+  })
+
+  observeEvent(input$addGwasCustomTrackButton, {
+    printf("---- addGWASTrack, custom columns and colors")
+    showGenomicRegion(session, id = "igvShiny_0", "chr19:45,248,108-45,564,645")
+    # headers igv.js has no chance of guessing: the same table draws an empty
+    # track unless the column numbers are spelled out
+    tbl <- tbl.gwas
+    names(tbl)[c(3, 4, 10)] <- c("chromosome_label", "bp_location", "significance")
+    track <- GWASTrack("gwas, custom columns", tbl,
+                       chrom.col = 3, pos.col = 4, pval.col = 10,
+                       trackHeight = 200,
+                       chromosomeColorMap = list("19" = "purple", "*" = "gray"))
+    display(track, session, id = "igvShiny_0", deleteTracksOfSameName = FALSE)
   })
 
   observeEvent(input$addBamViaHttpButton, {

--- a/man/loadGwasTrack.Rd
+++ b/man/loadGwasTrack.Rd
@@ -32,7 +32,11 @@ loadGwasTrack(
 \item{deleteTracksOfSameName}{logical, default TRUE}
 
 \item{trackConfig}{a named list of additional igv.js track configuration
-options.}
+options. A table whose headers igv.js does not recognize needs its layout
+spelled out, 1-based, as
+\code{columns = list(chromosome = 3, position = 4, value = 10)};
+\code{colorTable} takes a chromosome-to-color map, see
+\code{\link{GWASTrack}}}
 }
 \value{
 nothing

--- a/tests/testthat/test-loadTracks.R
+++ b/tests/testthat/test-loadTracks.R
@@ -101,6 +101,22 @@ test_that("loadGwasTrack writes the table and sets the y-axis limits", {
   expect_false(msg$autoscale)
 })
 
+test_that("loadGwasTrack carries a column mapping and color table through", {
+  session <- fake_session()
+  f <- system.file(package = "igvShiny", "extdata", "gwas.RData")
+  tbl.gwas <- get(load(f))
+  columns <- list(chromosome = 3, position = 4, value = 10)
+  colors <- list("19" = "purple", "*" = "gray")
+  # the documented way for a loadGwasTrack caller to reach what GWASTrack takes
+  # as arguments, so the allowlist and the loader have to agree
+  loadGwasTrack(session, ELEMENT_ID, "gwas", tbl.gwas,
+                trackConfig = list(columns = columns, colorTable = colors))
+
+  msg <- last_message(session, "loadGwasTrack")
+  expect_equal(msg$columns, columns)
+  expect_equal(msg$colorTable, colors)
+})
+
 test_that("loadBamTrackFromURL sends both the bam and the index url", {
   session <- fake_session()
   loadBamTrackFromURL(session, ELEMENT_ID, "bam",

--- a/tests/testthat/test-trackConfig.R
+++ b/tests/testthat/test-trackConfig.R
@@ -23,6 +23,13 @@ test_that("valid igv.js options are merged in", {
   expect_equal(merged$trackName, "t")
 })
 
+test_that("a gwas column mapping reaches igv.js through trackConfig", {
+  base <- list(elementID = "igvShiny_0", trackName = "t")
+  columns <- list(chromosome = 3, position = 4, value = 10)
+  merged <- sanitizeAndMergeOptions(base, list(columns = columns))
+  expect_equal(merged$columns, columns)
+})
+
 test_that("options outside the allowlist are dropped with a warning", {
   base <- list(elementID = "igvShiny_0")
   expect_warning(


### PR DESCRIPTION
Follow-up to #142, which wired the column mapping into the `GWASTrack` S4 class. `loadGwasTrack()` — the function most callers actually reach for — still had no way to send one: the `trackConfig` allowlist dropped `columns` as an unsupported igv.js option.

- `columns` joins `.validIgvTrackOptions`, so `loadGwasTrack(..., trackConfig = list(columns = list(chromosome = 3, position = 4, value = 10)))` works
- the `trackConfig` docs on `loadGwasTrack` now name both `columns` and `colorTable`
- the Connect Cloud demo gains a **GWAS (columns + colors)** button: it renames the gwas table's columns to names igv.js has no chance of guessing, then loads it with explicit column numbers and `chromosomeColorMap = list("19" = "purple", "*" = "gray")`

Without that button the two features from #142 and #46 have nowhere to be seen — the existing GWAS button works only because `gwas.RData` happens to use headers igv.js recognises (`CHR_ID`/`CHR_POS`/`P.VALUE`).

**Verified end to end in a headless browser**, probing the live igv.js track object after the click:

```json
{"features": 2438, "useChrColors": true, "color19": "purple", "colorOther": "gray"}
```

All 2438 rows parsed from the renamed table, and the color map reaching the track — proof the mapping is what makes the difference, not header luck. That probe is not committed as a test: the R-level contract (what the message carries) is already covered by unit tests, and pinning igv.js internals in CI would be brittle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qp8soQe3fbShVoyHhv58g8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom GWAS column mappings via `trackConfig`, including `columns` and `colorTable`.
  * Extended the Connect Cloud demo with a GWAS track option using custom columns and chromosome-based colours.
* **Bug Fixes**
  * Improved preservation and forwarding of user-supplied GWAS column configurations through option sanitisation.
* **Documentation**
  * Documented how to map unrecognised GWAS table headers and noted the 1-based column layout expectation.
  * Added release notes for version 1.9.25.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->