### PR TITLE
fix: take the dead asset URLs out of the stock genome definitions (#143)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.28
+Version: 1.9.29
 Date: 2026-07-27
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## igvShiny 1.9.29
+* Resolve tair10 through the igv.js registry, dropping the self-hosted fasta (#143)
+* Read the rhos sequence and genes from the UCSC assembly hub instead of gladki.pl (#143)
+* Remove the hg19 Gencode v18 track, whose s3 bucket answers 403 (#143)
+
 ## igvShiny 1.9.28
 * Fix a second igvShiny widget staying silent at a locus another one already reports (#126)
 * Add a headless test moving two widgets on one page to the same region

--- a/inst/demos/igvShinyDemo-GWASTrackClass.R
+++ b/inst/demos/igvShinyDemo-GWASTrackClass.R
@@ -8,7 +8,9 @@ library(GenomicAlignments)
 # zero pvalues, which when transformed by -log10, become
 # infinite, not conducive to autoscaled display.
 #----------------------------------------------------------------
-url <- "https://s3.amazonaws.com/igv.org.demo/gwas_sample.tsv.gz"
+# the igv.org.demo bucket dropped this file; the same table is the one the
+# GWASTrack examples already use (issue #143)
+url <- "https://gladki.pl/igvShiny/gwas_sample.tsv.gz"
 url.gwasTrack <- GWASTrack("remote url gwas",
                            url,
                            chrom.col=3,

--- a/inst/htmlwidgets/igvShiny.js
+++ b/inst/htmlwidgets/igvShiny.js
@@ -242,20 +242,16 @@ function genomeSpecificOptions(genomeName, stockGenome, dataMode, initialLocus, 
            }
         } // if annotation (gff3) supplied
     
+    // The Gencode v18 track this used to carry came from the
+    // igv.broadinstitute.org s3 bucket, which now answers 403. The registry
+    // entry for hg19 ships a RefSeq All track, so the annotation comes with the
+    // bare id and there is nothing left for us to pin (issue #143)
     var hg19_options = {
         locus: initialLocus,
         flanking: 1000,
         showRuler: true,
         minimumBases: 5,
-        
-        reference: {id: "hg19"},
-        tracks: [
-            {name: 'Gencode v18',
-             url: "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/gencode.v18.collapsed.bed",
-             indexURL: "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/gencode.v18.collapsed.bed.idx",
-             visibilityWindow: 2000000,
-             displayMode: displayMode
-            }]
+        genome: "hg19"
         }; // hg19_options
     
     
@@ -279,6 +275,11 @@ function genomeSpecificOptions(genomeName, stockGenome, dataMode, initialLocus, 
         genome: "mm10"
         }; // mm10_options
     
+    // tair10 is in the igv.js registry, sequence and RefSeq annotation included,
+    // so the bare id replaces the fasta we used to host ourselves - it has been
+    // answering 404 since the igvr paths were cleared (issue #143). Chromosomes
+    // arrive under their RefSeq accessions (NC_003070.9 ...) rather than the
+    // lowered chr names of the old GFF3
     var tair10_options = {
         locus: initialLocus,
         flanking: 2000,
@@ -286,24 +287,14 @@ function genomeSpecificOptions(genomeName, stockGenome, dataMode, initialLocus, 
         showNavigation: true,
         minimumBases: 5,
         showRuler: true,
-        reference: {id: "TAIR10",
-                    fastaURL: "https://gladki.pl/igvr/static/tair10/Arabidopsis_thaliana.TAIR10.dna.toplevel.fa",
-                    indexURL: "https://gladki.pl/igvr/static/tair10/Arabidopsis_thaliana.TAIR10.dna.toplevel.fa.fai",
-                    aliasURL: "https://gladki.pl/igvr/static/tair10/chromosomeAliases.txt"
-                   },
-        tracks: [
-            {name: 'Genes TAIR10',
-             type: 'annotation',
-             visibilityWindow: 500000,
-             url: "https://gladki.pl/igvr/static/tair10/TAIR10_genes.sorted.chrLowered.gff3.gz",
-             color: "darkred",
-             indexed: true,
-             height: trackHeight,
-             displayMode: displayMode
-            },
-        ]
+        genome: "tair10"
     }; // tair10_options
-    
+
+    // rhos is in no igv.js registry, but UCSC publishes the same assembly as an
+    // assembly hub, so the sequence and the genes come from there instead of
+    // from us. GCF_000012905.2 is ASM1290v2, the accession the old self-hosted
+    // filenames already carried (issue #143)
+    var rhos_hub = "https://hgdownload.soe.ucsc.edu/hubs/GCF/000/012/905/GCF_000012905.2";
     var rhos_options = {
         locus: initialLocus,
         flanking: 2000,
@@ -311,17 +302,18 @@ function genomeSpecificOptions(genomeName, stockGenome, dataMode, initialLocus, 
         showNavigation: true,
         minimumBases: 5,
         showRuler: true,
-        reference: {id: "Rhodobacter sphaeroides",
-                    fastaURL: "https://gladki.pl/igvr/static/rhos/GCF_000012905.2_ASM1290v2_genomic.fna",
-                    indexURL: "https://gladki.pl/igvr/static/rhos/GCF_000012905.2_ASM1290v2_genomic.fna.fai"
+        reference: {id: "GCF_000012905.2",
+                    name: "R. sphaeroides 2.4.1 (ASM1290v2)",
+                    twoBitURL: rhos_hub + "/GCF_000012905.2.2bit",
+                    aliasURL: rhos_hub + "/GCF_000012905.2.chromAlias.txt",
+                    chromSizesURL: rhos_hub + "/GCF_000012905.2.chrom.sizes.txt"
                    },
         tracks: [
             {name: 'Genes',
-             type: 'annotation',
+             format: 'bigbed',
              visibilityWindow: 500000,
-             url: "https://gladki.pl/igvr/static/rhos/GCF_000012905.2_ASM1290v2_genomic.gff.gz",
+             url: rhos_hub + "/bbi/GCF_000012905.2_ASM1290v2.ncbiGene.bb",
              color: "darkred",
-             indexed: true,
              height: trackHeight,
              displayMode: displayMode
             }


### PR DESCRIPTION
Six of the nine URLs from #143 are ours, and none of them needs a file put back on a server.

| Genome / demo | Was | Now |
|---|---|---|
| `tair10` | four self-hosted files under `gladki.pl/igvr/static/tair10` | bare id — the igv.js registry entry carries a UCSC twoBit and a RefSeq track |
| `rhos` | two self-hosted files under `gladki.pl/igvr/static/rhos` | UCSC assembly hub `GCF/000/012/905/GCF_000012905.2` |
| `hg19` | Gencode v18 from `igv.broadinstitute.org` (403) | nothing — the registry entry ships a RefSeq All track |
| GWASTrack demo | `igv.org.demo/gwas_sample.tsv.gz` (404) | the copy already served next to the package examples |

`GCF_000012905.2` is ASM1290v2, the accession the old self-hosted filenames already carried, so it is the same assembly and not a substitute.

**Behaviour change worth knowing:** `tair10` chromosomes now arrive as RefSeq accessions (`NC_003070.9` …) rather than the lowered `chr` names of the GFF3 we used to serve. Anyone passing an explicit `tair10` locus will need the new spelling. Both genomes are 404 on master today, so this is not a regression from a working state.

## Verification status — read before merging

- **HTTP level, done:** every URL introduced here answers 200 (`GCF_000012905.2.2bit`, `.chromAlias.txt`, `.chrom.sizes.txt`, `bbi/GCF_000012905.2_ASM1290v2.ncbiGene.bb`, and the tair10 hub files behind the registry entry). The registry entries were read from `genomes3.json` directly.
- **In a browser, NOT done.** No headless run confirms these three genomes render. The obvious vehicle, `inst/demos/stockGenomesDemo.R`, opens on `danRer11`, which still goes through the #114 workaround on master and hangs `igvReady` — the failure mode where nothing appears in the console at all. That path clears once #145 lands.

So: **#145 first, then a browser check on this branch, then merge.** Version is 1.9.29 to stay out of the way of 1.9.27/1.9.28.

Leaves one item in #143 that genuinely needs the server: the three SARS files under `/igvr/testFiles/sarsGenome/`, used by the custom-genome demos and `vignettes/igvShiny.Rmd`. Those demonstrate user-supplied files over http, so they have to be hosted somewhere — and re-pointing them at Ensembl risks the CORS failure mode rather than a clean 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qp8soQe3fbShVoyHhv58g8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for resolving the `tair10` genome through the IGV registry.
  - Updated `rhos` sequence and gene data to use the UCSC assembly hub.
  - Updated the GWAS demo to use a replacement sample data source.

- **Bug Fixes**
  - Removed the unavailable `hg19` Gencode v18 track, preventing failed data requests.

- **Chores**
  - Released version 1.9.29.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->