### PR TITLE
feat: let alignment tracks sort reads by a bam tag at load time (#104)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.29
-Date: 2026-07-27
+Version: 1.9.30
+Date: 2026-07-28
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 
     email = "paul.thurmond.shannon@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## igvShiny 1.9.30
+* Allow alignment tracks to sort their reads by a bam tag through trackConfig (#104)
+* Add a test pinning the sort object sent to igv.js
+
 ## igvShiny 1.9.29
 * Resolve tair10 through the igv.js registry, dropping the self-hosted fasta (#143)
 * Read the rhos sequence and genes from the UCSC assembly hub instead of gladki.pl (#143)

--- a/R/igvShiny.R
+++ b/R/igvShiny.R
@@ -22,7 +22,10 @@
   "columns",
   "showAllBases", "samplingWindowSize", "samplingDepth", "maxRows",
   "hideEmptyTracks", "oauthToken", "headers", "viewAsPairs", "pairsSupported",
-  "maxPanelHeight", "separateBam", "wholeGenomeView", "roi", "queryable"
+  "maxPanelHeight", "separateBam", "wholeGenomeView", "roi", "queryable",
+  ## alignment tracks sort their reads at load time from this object, the same
+  ## one the igv.js right-click menu builds; "TAG" plus a tag covers #104
+  "sort"
   # Add other valid igv.js track options here as needed in the future
 )
 
@@ -998,7 +1001,11 @@ loadGwasTrack <- function(session,
 #' "SQUISHED" or "COLLAPSED"
 #' @param showAllBases logical, show all bases in the alignment, default FALSE
 #' @param trackConfig a named list of additional igv.js track configuration
-#' options.
+#' options. Alignment tracks read \code{sort}: \code{list(sort =
+#' list(chr = "chr1", position = 155160540, option = "TAG", tag = "HP"))}
+#' sorts the reads at that 1-based position by the HP tag. Any igv.js sort
+#' option works (BASE, STRAND, INSERT_SIZE, ...); reads sort descending
+#' unless \code{direction = "ASC"}.
 #'
 #' @examples
 #' library(igvShiny)
@@ -1061,7 +1068,7 @@ loadBamTrackFromURL <-
 #' @param displayMode character string, possible values are "EXPANDED"(default),
 #' "SQUISHED" or "COLLAPSED"
 #' @param trackConfig a named list of additional igv.js track configuration
-#' options.
+#' options, \code{sort} among them; see \code{\link{loadBamTrackFromURL}}.
 #'
 #' @examples
 #' library(igvShiny)
@@ -1134,7 +1141,7 @@ loadBamTrackFromLocalData <-
 #' typically small
 #' @param deleteTracksOfSameName logical, default TRUE
 #' @param trackConfig a named list of additional igv.js track configuration
-#' options.
+#' options, \code{sort} among them; see \code{\link{loadBamTrackFromURL}}.
 #'
 #' @examples
 #' library(igvShiny)

--- a/man/loadBamTrackFromLocalData.Rd
+++ b/man/loadBamTrackFromLocalData.Rd
@@ -29,7 +29,7 @@ loadBamTrackFromLocalData(
 "SQUISHED" or "COLLAPSED"}
 
 \item{trackConfig}{a named list of additional igv.js track configuration
-options.}
+options, \code{sort} among them; see \code{\link{loadBamTrackFromURL}}.}
 }
 \value{
 nothing

--- a/man/loadBamTrackFromURL.Rd
+++ b/man/loadBamTrackFromURL.Rd
@@ -37,7 +37,11 @@ typically small}
 \item{showAllBases}{logical, show all bases in the alignment, default FALSE}
 
 \item{trackConfig}{a named list of additional igv.js track configuration
-options.}
+options. Alignment tracks read \code{sort}: \code{list(sort =
+list(chr = "chr1", position = 155160540, option = "TAG", tag = "HP"))}
+sorts the reads at that 1-based position by the HP tag. Any igv.js sort
+option works (BASE, STRAND, INSERT_SIZE, ...); reads sort descending
+unless \code{direction = "ASC"}.}
 }
 \value{
 nothing

--- a/man/loadCramTrackFromURL.Rd
+++ b/man/loadCramTrackFromURL.Rd
@@ -30,7 +30,7 @@ typically small}
 \item{deleteTracksOfSameName}{logical, default TRUE}
 
 \item{trackConfig}{a named list of additional igv.js track configuration
-options.}
+options, \code{sort} among them; see \code{\link{loadBamTrackFromURL}}.}
 }
 \value{
 nothing

--- a/tests/testthat/test-loadTracks.R
+++ b/tests/testthat/test-loadTracks.R
@@ -18,6 +18,13 @@ bed_tbl <- function() {
   )
 }
 
+# igv.js sorts an alignment track from this object at load time. Each loader
+# builds its own payload, so a dropped trackConfig is a per-loader regression.
+sort_by_hp <- function() {
+  list(chr = "chr1", position = 155160540, option = "TAG", tag = "HP",
+       direction = "ASC")
+}
+
 test_that("loadBedTrack sends a bed file path and honours colour and height", {
   session <- fake_session()
   loadBedTrack(session, ELEMENT_ID, "bed", bed_tbl(),
@@ -195,22 +202,27 @@ test_that("loadBamTrackFromLocalData exports the alignments to the tracks dir", 
   session <- fake_session()
   f <- system.file(package = "igvShiny", "extdata", "tumor.bam")
   ga <- GenomicAlignments::readGAlignments(f, use.names = TRUE)
-  loadBamTrackFromLocalData(session, ELEMENT_ID, "local bam", ga)
+  loadBamTrackFromLocalData(session, ELEMENT_ID, "local bam", ga,
+                            trackConfig = list(sort = sort_by_hp()))
 
   msg <- last_message(session, "loadBamTrackFromLocalData")
   expect_match(msg$bamDataFilepath, "^tracks/.*\\.bam$")
+  expect_equal(msg$sort, sort_by_hp())
 })
 
-test_that("loadBamTrackFromURL passes a sort-by-tag object through (#104)", {
+test_that("the alignment loaders pass a sort-by-tag object through (#104)", {
   session <- fake_session()
-  sortByHP <- list(chr = "chr1", position = 155160540, option = "TAG",
-                   tag = "HP", direction = "ASC")
   loadBamTrackFromURL(session, ELEMENT_ID, "bam",
                       "https://example.org/a.bam", "https://example.org/a.bai",
-                      trackConfig = list(sort = sortByHP))
+                      trackConfig = list(sort = sort_by_hp()))
+  expect_equal(last_message(session, "loadBamTrackFromURL")$sort, sort_by_hp())
 
-  msg <- last_message(session, "loadBamTrackFromURL")
-  expect_equal(msg$sort, sortByHP)
+  session <- fake_session()
+  loadCramTrackFromURL(session, ELEMENT_ID, "cram",
+                       "https://example.org/a.cram",
+                       "https://example.org/a.crai",
+                       trackConfig = list(sort = sort_by_hp()))
+  expect_equal(last_message(session, "loadCramTrackFromURL")$sort, sort_by_hp())
 })
 
 test_that("the navigation and removal helpers send their own messages", {

--- a/tests/testthat/test-loadTracks.R
+++ b/tests/testthat/test-loadTracks.R
@@ -201,6 +201,18 @@ test_that("loadBamTrackFromLocalData exports the alignments to the tracks dir", 
   expect_match(msg$bamDataFilepath, "^tracks/.*\\.bam$")
 })
 
+test_that("loadBamTrackFromURL passes a sort-by-tag object through (#104)", {
+  session <- fake_session()
+  sortByHP <- list(chr = "chr1", position = 155160540, option = "TAG",
+                   tag = "HP", direction = "ASC")
+  loadBamTrackFromURL(session, ELEMENT_ID, "bam",
+                      "https://example.org/a.bam", "https://example.org/a.bai",
+                      trackConfig = list(sort = sortByHP))
+
+  msg <- last_message(session, "loadBamTrackFromURL")
+  expect_equal(msg$sort, sortByHP)
+})
+
 test_that("the navigation and removal helpers send their own messages", {
   session <- fake_session()
   showGenomicRegion(session, ELEMENT_ID, "chr1:1-1000")


### PR DESCRIPTION
Closes #104.

igv.js 3.8.4 already sorts an alignment track from a `sort` object in the track config — the constructor runs `config.sort && this.assignSort(config.sort)`. Our allowlist dropped the key before it reached the browser, so sorting by `HP` was reachable only from the igv.js right-click menu.

Allowing `sort` through covers every igv.js sort option (`TAG`, `BASE`, `STRAND`, `INSERT_SIZE`, ...) for all three alignment loaders, with no new argument on each:

```r
loadBamTrackFromURL(session, "igvShiny_0", "tumor", bamURL, baiURL,
  trackConfig = list(sort = list(chr = "chr1", position = 155160540,
                                 option = "TAG", tag = "HP", direction = "ASC")))
```

Two igv.js quirks are now in the `trackConfig` docs: `position` is 1-based (`assignSort` decrements it when no `locus` is given), and reads sort descending unless `direction = "ASC"`.

Runtime sorting of an already-loaded track (`track.sort()` behind a new message handler) is deliberately out of scope — the issue asks for sorting when loading tracks.

Test: `test-loadTracks.R` pins the sort object in the payload sent to igv.js.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Alignment tracks can now sort reads by a specified BAM tag via track configuration, including ascending or descending order.
* **Documentation**
  * Added clearer guidance on configuring read sorting with tags such as `HP`.
* **Tests**
  * Added coverage confirming that sorting options are correctly forwarded to the visualisation engine.
* **Release**
  * Updated the package to version 1.9.30 (dated 28 July 2026).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->