### PR TITLE
fix: report the locus start as 1-based in currentGenomicRegion (#126)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.32
+Version: 1.9.33
 Date: 2026-07-29
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## igvShiny 1.9.33
+* Fix the off-by-one start in currentGenomicRegion, closing its round trip through showGenomicRegion (#126)
+
 ## igvShiny 1.9.32
 * Add loadSpliceJunctionTrackFromURL, drawing STAR splice junctions from a bed file (#103)
 * Extend the track option allowlist with the igv.js splice junction filters and labels (#103)

--- a/inst/htmlwidgets/igvShiny.js
+++ b/inst/htmlwidgets/igvShiny.js
@@ -106,10 +106,15 @@ HTMLWidgets.widget({
                    // first frame and rebuild the comma-free "chr:start-end" string that
                    // currentGenomicRegion has always emitted, guarding the whole-genome
                    // "all" view (raw start/end are meaningless there).
+                   //
+                   // The frame start is 0-based internally, while browser.search() reads
+                   // its input as 1-based and subtracts one. Emitting the raw value cost
+                   // a base per round trip, so an app that reported a region and later
+                   // sent it back crept left one step at a time (#126).
                    var refFrame = referenceFrameList[0];
                    var chromLocString = (refFrame.chr === "all")
                       ? "all"
-                      : refFrame.chr + ":" + Math.round(refFrame.start) + "-" + Math.round(refFrame.end);
+                      : refFrame.chr + ":" + (Math.floor(refFrame.start) + 1) + "-" + Math.round(refFrame.end);
                    
                    // Compare against this widget's own last locus, not a global:
                    // two widgets sitting at the same locus would otherwise

--- a/tests/testthat/test-shinyApp.R
+++ b/tests/testthat/test-shinyApp.R
@@ -195,11 +195,17 @@ test_that("two widgets at the same locus both report it", {
         Sys.sleep(0.5)
     }
 
-    # each widget reports the chromosome it was sent to; the exact span is left
-    # out of the assertion because igv.js fits the range to the viewport
+    # each widget reports the chromosome it was sent to; the end is left out of
+    # the assertion because igv.js fits the range to the viewport
     expect_true(nzchar(regions[1]))
     expect_true(nzchar(regions[2]))
     expect_true(all(startsWith(regions, "U13369.1:")))
+
+    # the reported start matches the one sent, rather than trailing it by a
+    # base: the frame start is 0-based and showGenomicRegion reads 1-based, so
+    # emitting it raw made every round trip creep one to the left (#126)
+    starts <- as.integer(sub("^[^:]+:([0-9]+)-.*$", "\\1", regions))
+    expect_equal(starts, c(7276L, 7276L))
 
     app$stop()
 })


### PR DESCRIPTION
Second point of #126. The first one landed in #147.

## The bug

`currentGenomicRegion` emits the reference frame start as igv.js holds it internally, 0-based. `showGenomicRegion` hands its input to `browser.search()`, which reads it as 1-based and subtracts one (`Locus.fromLocusString`). Feeding a reported region back therefore loses a base — and it loses one on every cycle, so it drifts rather than sitting at a fixed offset. Measured in the browser on the bundled igv.js 3.8.4:

```
sent  : U13369.1:7,276-8,225
hop 1 : U13369.1:7275-8225
hop 2 : U13369.1:7274-8225
hop 5 : U13369.1:7271-8225
```

An app that remembers a view and later returns to it creeps left, with nothing in the console to show for it.

## The fix

One line: emit `Math.floor(start) + 1`.

The format is otherwise untouched, deliberately. `ReferenceFrame.getLocusString()` would also add thousands separators and swap in display chromosome names, and both reach user code: `as.integer("7,276")` returns `NA` with a warning rather than an error, so a comma turns working consumer code into a silent `NA` factory, and the display name changes the chromosome string for registry genomes such as tair10. A structured event carrying `chr`/`start`/`end` as numbers is the clean long-term answer, but that is new API and belongs in its own PR.

In-package consumers were checked — six demos, `demo/posit-connect/app.R`, the tests — and all of them only display the string. The exposure is entirely in user apps.

## Test

The existing #126 test already drove a widget to `U13369.1:7,276-8,225`, but asserted only the chromosome prefix, so the drift passed straight through it. It now pins the reported start to 7276.

Credit to @M4teuszzGl4dki for the measurement and the format analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected an off-by-one error when reporting genomic regions after navigating to a location.
  * Genomic region start coordinates are now reported consistently using the expected one-based format.

* **Tests**
  * Improved coverage to verify matching and accurate region start coordinates across multiple widgets.

* **Chores**
  * Updated the package version to 1.9.33 and documented the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->