### PR TITLE
docs: record the tair10 gene track rename in NEWS (#143)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.33
+Version: 1.9.34
 Date: 2026-07-29
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## igvShiny 1.9.34
+* Rename the tair10 gene track to the registry name, breaking removeTracksByName on the old label (#143)
+
 ## igvShiny 1.9.33
 * Fix the off-by-one start in currentGenomicRegion, closing its round trip through showGenomicRegion (#126)
 

--- a/inst/htmlwidgets/igvShiny.js
+++ b/inst/htmlwidgets/igvShiny.js
@@ -282,9 +282,12 @@ function genomeSpecificOptions(genomeName, stockGenome, dataMode, initialLocus, 
     
     // tair10 is in the igv.js registry, sequence and RefSeq annotation included,
     // so the bare id replaces the fasta we used to host ourselves - it has been
-    // answering 404 since the igvr paths were cleared (issue #143). Chromosomes
-    // arrive under their RefSeq accessions (NC_003070.9 ...) rather than the
-    // lowered chr names of the old GFF3
+    // answering 404 since the igvr paths were cleared (issue #143). The registry
+    // entry carries an aliasURL, so data named chr1 or 1 still resolves; what
+    // changes is the displayed name, the RefSeq accession (NC_003070.9 ...).
+    // The annotation now comes from the registry as "RefSeq All" rather than the
+    // "Genes TAIR10" track this config used to carry, so code addressing it by
+    // the old name - removeTracksByName above all - no longer matches anything
     var tair10_options = {
         locus: initialLocus,
         flanking: 2000,


### PR DESCRIPTION
Follow-up to #148, which is already on master. Documentation only — no behaviour changes.

## What went unrecorded

Before #143 the tair10 config carried its own track:

```js
{name: 'Genes TAIR10', url: ".../TAIR10_genes.sorted.chrLowered.gff3.gz", ...}
```

tair10 is now the bare registry id, and the registry supplies the annotation as **`RefSeq All`**. The track is still there; it answers to a different name. So `removeTracksByName(session, id, "Genes TAIR10")` in a user app quietly does nothing — no error, no warning — and the same goes for any code or test addressing that track by name.

Scope was checked and it is tair10 alone:

| Genome | Name before | Name after | In NEWS? |
|---|---|---|---|
| tair10 | `Genes TAIR10` | `RefSeq All` | **no** |
| rhos | `Genes` | `Genes` (explicit hub track) | unchanged |
| hg19 | `Gencode v18` | removed | yes, 1.9.29 |

## The comment overstated the change

`igvShiny.js` said chromosomes "arrive under their RefSeq accessions rather than the lowered chr names of the old GFF3", which reads as: rename your data. Not so. The registry entry carries an `aliasURL` (`GCF_000001735.3.chromAlias.txt`), and igv.js resolves across every column of it:

```
# refseq      assembly  genbank      ncbi  ucsc
NC_003070.9   1         CP002684.1   1     chr1
```

Verified end to end in the browser on the bundled `igv-3.8.4.min.js`: `locus: "chr1:1-200000"` lands on `NC_003070.9:1-200,000`, and a track whose features are named `chr1` and one named `1` both draw. Only the displayed name changed. Fetching the alias file proves nothing on its own — the file can exist while igv.js ignores it — hence the check with a real track.

Reconnaissance and browser measurements by @M4teuszzGl4dki.

Version is 1.9.34, leaving 1.9.33 to #154; whichever merges first, the other needs a rebase for NEWS either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release notes for version 1.9.34.
  * Clarified that the TAIR10 gene track naming now follows the IGV registry and that using the previous label may break `removeTracksByName` (issue `#143`).
* **Chores**
  * Bumped the package version to 1.9.34.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->