### PR TITLE
Script the Connect re-pin and warn when the live demo falls behind

### DIFF
--- a/.github/workflows/connect-pin-check.yml
+++ b/.github/workflows/connect-pin-check.yml
@@ -1,0 +1,78 @@
+name: connect-pin-check
+
+# demo/posit-connect/app.R runs the demo out of the *installed* package, so the
+# commit pinned in manifest.json decides what the public demo shows. Merging a
+# demo change to master therefore changes nothing until the pin moves - and the
+# gap is invisible: CI is green, the repo is right, only the live app is stale.
+# It sat ten versions behind (1.9.25 vs 1.9.35) before anyone noticed.
+#
+# This does not deploy. Republishing is a click in Connect Cloud; all this does
+# is refuse to let the drift go unnoticed.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "inst/demos/**"
+      - "demo/posit-connect/**"
+      - ".github/workflows/connect-pin-check.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pin:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      TITLE: "Connect demo is behind master"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Check the pinned commit
+        id: check
+        run: |
+          set +e
+          ./demo/posit-connect/bump-pin.sh --check | tee "${{ runner.temp }}/pin.txt"
+          echo "status=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Connect Cloud pin"
+            echo
+            echo '```'
+            cat "${{ runner.temp }}/pin.txt"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+
+      - name: Open a reminder when the pin is behind
+        if: steps.check.outputs.status != '0'
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          body=$(
+            printf 'A demo change reached master, but `manifest.json` still pins an older commit, so the [public demo](https://gladkia-igvshiny-demo.share.connect.posit.cloud) does not show it yet.\n\n'
+            printf '```\n%s\n```\n\n' "$(cat "${{ runner.temp }}/pin.txt")"
+            printf 'To publish it:\n\n```bash\n./demo/posit-connect/bump-pin.sh\n```\n\nCommit the manifest, push to master, then republish in Connect Cloud. The sidebar footer must then read the version the script printed.\n\nRun: %s\n' "$RUN_URL"
+          )
+          existing=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            echo "Issue #$existing already open; not filing another."
+          else
+            gh issue create --title "$TITLE" --body "$body"
+          fi
+
+      # Bumping the pin in the same PR as the demo change is the normal path, so
+      # a green run here usually means there was never a reminder to close.
+      - name: Close the reminder once the pin catches up
+        if: steps.check.outputs.status == '0'
+        run: |
+          existing=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh issue close "$existing" --comment "The manifest now pins the current master; remember to republish in Connect Cloud."
+          fi

--- a/.github/workflows/connect-pin-check.yml
+++ b/.github/workflows/connect-pin-check.yml
@@ -22,6 +22,11 @@ on:
 permissions:
   contents: read
 
+# Two runs racing to `gh issue list` both see nothing open and both file one.
+concurrency:
+  group: connect-pin-check
+  cancel-in-progress: true
+
 jobs:
   pin:
     runs-on: ubuntu-latest
@@ -51,8 +56,18 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           exit 0
 
+      # The script separates the two: 1 means the manifest needs bumping,
+      # anything above means the check itself could not run (missing jq/gh, a
+      # commit that is not there, an API failure). Filing "the demo is behind"
+      # for a broken check would be a lie, and a quiet one.
+      - name: Fail when the check could not run
+        if: steps.check.outputs.status != '0' && steps.check.outputs.status != '1'
+        run: |
+          echo "bump-pin.sh exited ${{ steps.check.outputs.status }} - the check did not run" >&2
+          exit 1
+
       - name: Open a reminder when the pin is behind
-        if: steps.check.outputs.status != '0'
+        if: steps.check.outputs.status == '1'
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |

--- a/.github/workflows/connect-pin-check.yml
+++ b/.github/workflows/connect-pin-check.yml
@@ -1,13 +1,14 @@
 name: connect-pin-check
 
 # demo/posit-connect/app.R runs the demo out of the *installed* package, so the
-# commit pinned in manifest.json decides what the public demo shows. Merging a
-# demo change to master therefore changes nothing until the pin moves - and the
-# gap is invisible: CI is green, the repo is right, only the live app is stale.
-# It sat ten versions behind (1.9.25 vs 1.9.35) before anyone noticed.
+# commit pinned in manifest.json decides what the public demo shows. Connect
+# Cloud republishes on every master change by itself, but republishing does not
+# move the pin: it reinstalls igvShiny from the recorded SHA and faithfully
+# redeploys the old app. The gap is invisible - CI green, repo correct, only the
+# live app stale - which is how the pin sat ten versions behind (1.9.25 vs
+# 1.9.35) unnoticed.
 #
-# This does not deploy. Republishing is a click in Connect Cloud; all this does
-# is refuse to let the drift go unnoticed.
+# This deploys nothing and moves nothing. It only refuses to let that go unseen.
 
 on:
   push:
@@ -58,7 +59,7 @@ jobs:
           body=$(
             printf 'A demo change reached master, but `manifest.json` still pins an older commit, so the [public demo](https://gladkia-igvshiny-demo.share.connect.posit.cloud) does not show it yet.\n\n'
             printf '```\n%s\n```\n\n' "$(cat "${{ runner.temp }}/pin.txt")"
-            printf 'To publish it:\n\n```bash\n./demo/posit-connect/bump-pin.sh\n```\n\nCommit the manifest, push to master, then republish in Connect Cloud. The sidebar footer must then read the version the script printed.\n\nRun: %s\n' "$RUN_URL"
+            printf 'Connect republishes on its own, but that reinstalls igvShiny from the pinned SHA - it will keep redeploying the old app until the pin moves:\n\n```bash\n./demo/posit-connect/bump-pin.sh\n```\n\nCommit the manifest and push to master; the republish that follows picks it up. The sidebar footer must then read the version the script printed.\n\nRun: %s\n' "$RUN_URL"
           )
           existing=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number')
           if [ -n "$existing" ]; then

--- a/demo/posit-connect/README.md
+++ b/demo/posit-connect/README.md
@@ -44,19 +44,29 @@ that has not been released yet.
 
 ### Routine: publish what is on master
 
-After a demo change lands on master, move the pin — six fields have to stay in
-step (two SHAs, the recorded version, the file checksums), so use the script:
+Connect Cloud watches `master` and republishes on its own — **but republishing
+does not move the pin.** It rebuilds from the repo and then installs `igvShiny`
+from the SHA recorded in `manifest.json`, so an automatic republish against a
+stale pin faithfully redeploys the old app. The pin is the manual part.
+
+Six fields have to stay in step (two SHAs, the recorded version, the two file
+checksums), so use the script rather than editing the manifest by hand:
 
 ```bash
-./demo/posit-connect/bump-pin.sh --check   # is the live demo behind master?
+./demo/posit-connect/bump-pin.sh --check   # would the live demo differ from master?
 ./demo/posit-connect/bump-pin.sh           # re-pin to origin/master
 ./demo/posit-connect/bump-pin.sh <sha>     # or to one specific commit
 ```
 
-Then commit the manifest, push to master, and hit republish in Connect Cloud.
-Confirm it took: the sidebar footer must read the version the script printed.
+Best done **in the same PR as the demo change**, pinning to the commit the demo
+landed in. Merging then triggers the republish, which picks the new pin up, and
+nothing is left to remember. Confirm it took: the sidebar footer must read the
+version the script printed.
 
-`--check` exits non-zero on drift, so it also works as a post-merge reminder.
+`--check` compares what the pinned commit would *install* against master — only
+`R/`, `inst/` and `DESCRIPTION` reach the served app. It deliberately does not
+require the pin to equal `HEAD`: that is false after every merge, including the
+merge that moves the pin.
 
 ### When dependencies change
 

--- a/demo/posit-connect/README.md
+++ b/demo/posit-connect/README.md
@@ -42,24 +42,45 @@ that has not been released yet.
 > the page just greys out, with nothing in the UI to explain it. The sidebar
 > footer prints the installed `igvShiny` version — check it there first.
 
-Regenerate the manifest whenever the demo or its dependencies change, and make
-sure the locally installed `igvShiny` is the GitHub build first, so the manifest
-records the GitHub source rather than Bioconductor:
+### Routine: publish what is on master
 
-```r
-# install the dev version so writeManifest records source = github:
-remotes::install_github("gladkia/igvShiny", ref = "master")
+After a demo change lands on master, move the pin — six fields have to stay in
+step (two SHAs, the recorded version, the file checksums), so use the script:
 
-# then, from repo root, with rsconnect installed:
-rsconnect::writeManifest("demo/posit-connect")
+```bash
+./demo/posit-connect/bump-pin.sh --check   # is the live demo behind master?
+./demo/posit-connect/bump-pin.sh           # re-pin to origin/master
+./demo/posit-connect/bump-pin.sh <sha>     # or to one specific commit
 ```
 
-Then in the Connect Cloud UI:
+Then commit the manifest, push to master, and hit republish in Connect Cloud.
+Confirm it took: the sidebar footer must read the version the script printed.
+
+`--check` exits non-zero on drift, so it also works as a post-merge reminder.
+
+### When dependencies change
+
+The script only moves the pin. If the demo starts using a *new package*, the
+`packages` block has to be rebuilt — install the GitHub build first, so the
+manifest records the GitHub source rather than Bioconductor:
+
+```r
+remotes::install_github("gladkia/igvShiny", ref = "master")
+rsconnect::writeManifest("demo/posit-connect")   # from repo root
+```
+
+Note that `writeManifest` reformats the whole file; check the diff is only what
+you meant to change.
+
+### First-time setup (already done)
 
 1. **New content → from GitHub**, pick `gladkia/igvShiny`.
 2. Primary file: `demo/posit-connect/app.R`.
 3. Publish. Connect Cloud installs from `manifest.json` — CRAN via PPM for most
-   packages, and `igvShiny` straight from GitHub master — then serves the app.
+   packages, and `igvShiny` straight from GitHub — then serves the app.
+
+The source branch must be **master**: a feature branch disappears when the PR
+merges, and the next republish fails with nothing to point at.
 
 ## Caveat — external URL buttons
 

--- a/demo/posit-connect/README.md
+++ b/demo/posit-connect/README.md
@@ -53,20 +53,29 @@ Six fields have to stay in step (two SHAs, the recorded version, the two file
 checksums), so use the script rather than editing the manifest by hand:
 
 ```bash
-./demo/posit-connect/bump-pin.sh --check   # would the live demo differ from master?
+./demo/posit-connect/bump-pin.sh --check   # is the manifest behind master?
 ./demo/posit-connect/bump-pin.sh           # re-pin to origin/master
 ./demo/posit-connect/bump-pin.sh <sha>     # or to one specific commit
 ```
+
+Run it **last**, after any edit to `app.R` or this README — it records their
+checksums, so editing either one afterwards invalidates the manifest again.
 
 Best done **in the same PR as the demo change**, pinning to the commit the demo
 landed in. Merging then triggers the republish, which picks the new pin up, and
 nothing is left to remember. Confirm it took: the sidebar footer must read the
 version the script printed.
 
-`--check` compares what the pinned commit would *install* against master — only
-`R/`, `inst/` and `DESCRIPTION` reach the served app. It deliberately does not
-require the pin to equal `HEAD`: that is false after every merge, including the
-merge that moves the pin.
+`--check` reads the manifest against `gladkia/igvShiny`'s master — it cannot see
+what Connect actually has deployed, only whether the manifest still describes
+master. It compares what the pinned commit would *install* (`R/`, `inst/`,
+`DESCRIPTION` — the only paths that reach the served package) and verifies the
+manifest's own invariants: both SHA fields agreeing, the recorded version, and
+the two file checksums. It deliberately does not require the pin to equal
+`HEAD`, which is false after every merge, including the merge that moves it.
+
+The deployment itself is verified in one place only: the version in the app's
+sidebar footer.
 
 ### When dependencies change
 

--- a/demo/posit-connect/bump-pin.sh
+++ b/demo/posit-connect/bump-pin.sh
@@ -53,11 +53,26 @@ old_ver="$(jq -r '.packages.igvShiny.description.Version' "$manifest")"
 echo "pinned:  $old_ver  ${old_sha:0:7}"
 echo "target:  $version  ${sha:0:7}"
 
-if [[ "$old_sha" == "$sha" ]]; then
-  echo "manifest already pinned to this commit"
-  $check_only && exit 0
+# Drift is not "the pin differs from HEAD" - that is true right after every
+# merge, including the merge that moves the pin, and a check that cries wolf
+# once a week is a check nobody reads. What matters is whether the pinned
+# commit would install a different app: only R/, inst/ and DESCRIPTION reach
+# the served package.
+stale_files=""
+if [[ "$old_sha" != "$sha" ]]; then
+  stale_files="$(gh api "repos/$repo/compare/$old_sha...$sha" \
+                   --jq '.files[].filename' 2>/dev/null \
+                 | grep -E '^(R/|inst/|DESCRIPTION$)' || true)"
 fi
-$check_only && { echo "DRIFT: the live demo serves ${old_sha:0:7}, not ${sha:0:7}"; exit 1; }
+
+if [[ -z "$stale_files" ]]; then
+  echo "the pinned commit installs the same app as master"
+  $check_only && exit 0
+else
+  echo "the pinned commit predates these changes to the served app:"
+  echo "$stale_files" | sed 's/^/  /' | head -20
+  $check_only && { echo "DRIFT: the live demo runs ${old_sha:0:7}, not ${sha:0:7}"; exit 1; }
+fi
 
 app_md5="$(md5of "$dir/app.R")"
 readme_md5="$(md5of "$dir/README.md")"

--- a/demo/posit-connect/bump-pin.sh
+++ b/demo/posit-connect/bump-pin.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Re-pin the Connect Cloud manifest to a commit of gladkia/igvShiny.
+#
+# Connect installs igvShiny from the SHA recorded in manifest.json, and app.R
+# runs the demo out of that installed package - so this pin, not the branch,
+# decides what the public demo shows. Merging a demo change to master does
+# nothing until the pin moves.
+#
+#   ./demo/posit-connect/bump-pin.sh            # pin to origin/master
+#   ./demo/posit-connect/bump-pin.sh <sha>      # pin to a specific commit
+#   ./demo/posit-connect/bump-pin.sh --check    # report drift, change nothing
+#
+# Six fields have to stay in step (two SHAs, the version, two file checksums),
+# which is why this is a script and not a paragraph in the README.
+
+set -euo pipefail
+
+repo="gladkia/igvShiny"
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+manifest="$dir/manifest.json"
+
+command -v jq >/dev/null || { echo "need jq" >&2; exit 2; }
+command -v gh >/dev/null || { echo "need gh" >&2; exit 2; }
+
+md5of() {  # macOS has md5, GNU has md5sum
+  if command -v md5sum >/dev/null; then md5sum "$1" | cut -d' ' -f1
+  else md5 -q "$1"; fi
+}
+
+check_only=false
+sha=""
+case "${1:-}" in
+  --check) check_only=true ;;
+  "")      ;;
+  *)       sha="$1" ;;
+esac
+
+# the full 40-char sha, always: the GitHub API silently returns nothing for
+# an abbreviated one, which reads exactly like "this commit does not exist"
+[[ -n "$sha" ]] || sha="$(gh api "repos/$repo/commits/master" --jq .sha)"
+[[ ${#sha} -eq 40 ]] || { echo "not a full 40-char sha: $sha" >&2; exit 2; }
+
+gh api "repos/$repo/commits/$sha" --jq .sha >/dev/null \
+  || { echo "commit $sha not found in $repo" >&2; exit 2; }
+
+# the package version as recorded at that commit, not the working tree's
+version="$(gh api "repos/$repo/contents/DESCRIPTION?ref=$sha" --jq '.content' \
+           | base64 -d | awk '/^Version:/ {print $2}')"
+
+old_sha="$(jq -r '.packages.igvShiny.description.RemoteSha' "$manifest")"
+old_ver="$(jq -r '.packages.igvShiny.description.Version' "$manifest")"
+
+echo "pinned:  $old_ver  ${old_sha:0:7}"
+echo "target:  $version  ${sha:0:7}"
+
+if [[ "$old_sha" == "$sha" ]]; then
+  echo "manifest already pinned to this commit"
+  $check_only && exit 0
+fi
+$check_only && { echo "DRIFT: the live demo serves ${old_sha:0:7}, not ${sha:0:7}"; exit 1; }
+
+app_md5="$(md5of "$dir/app.R")"
+readme_md5="$(md5of "$dir/README.md")"
+
+tmp="$(mktemp)"
+jq --arg sha "$sha" --arg version "$version" \
+   --arg app "$app_md5" --arg readme "$readme_md5" '
+  .packages.igvShiny.description.RemoteSha  = $sha
+  | .packages.igvShiny.description.GithubSHA1 = $sha
+  | .packages.igvShiny.description.Version    = $version
+  | .files["app.R"].checksum                  = $app
+  | .files["README.md"].checksum              = $readme
+' "$manifest" > "$tmp"
+
+jq -e . "$tmp" >/dev/null || { echo "produced invalid json, manifest untouched" >&2; exit 1; }
+mv "$tmp" "$manifest"
+
+echo "manifest re-pinned; commit it, push to master, then republish in Connect Cloud."
+echo "the app's sidebar footer should read: igvShiny $version"

--- a/demo/posit-connect/bump-pin.sh
+++ b/demo/posit-connect/bump-pin.sh
@@ -43,9 +43,13 @@ esac
 gh api "repos/$repo/commits/$sha" --jq .sha >/dev/null \
   || { echo "commit $sha not found in $repo" >&2; exit 2; }
 
-# the package version as recorded at that commit, not the working tree's
-version="$(gh api "repos/$repo/contents/DESCRIPTION?ref=$sha" --jq '.content' \
-           | base64 -d | awk '/^Version:/ {print $2}')"
+# the package version as recorded at that commit, not the working tree's.
+# Asking for the raw media type keeps base64 out of it: the -d/-D flag split
+# between GNU and macOS coreutils is a portability trap for no gain.
+version="$(gh api "repos/$repo/contents/DESCRIPTION?ref=$sha" \
+             -H "Accept: application/vnd.github.raw" \
+           | awk '/^Version:/ {print $2}')"
+[[ -n "$version" ]] || { echo "no Version: in DESCRIPTION at $sha" >&2; exit 2; }
 
 old_sha="$(jq -r '.packages.igvShiny.description.RemoteSha' "$manifest")"
 old_ver="$(jq -r '.packages.igvShiny.description.Version' "$manifest")"
@@ -65,17 +69,31 @@ if [[ "$old_sha" != "$sha" ]]; then
                  | grep -E '^(R/|inst/|DESCRIPTION$)' || true)"
 fi
 
-if [[ -z "$stale_files" ]]; then
-  echo "the pinned commit installs the same app as master"
-  $check_only && exit 0
-else
-  echo "the pinned commit predates these changes to the served app:"
-  echo "$stale_files" | sed 's/^/  /' | head -20
-  $check_only && { echo "DRIFT: the live demo runs ${old_sha:0:7}, not ${sha:0:7}"; exit 1; }
-fi
-
 app_md5="$(md5of "$dir/app.R")"
 readme_md5="$(md5of "$dir/README.md")"
+
+# The pin is only half of it: Connect also verifies the file checksums, and the
+# two sha fields are read by different parts of rsconnect. A manifest that is
+# internally inconsistent deploys something nobody described.
+inconsistent=""
+[[ "$(jq -r '.packages.igvShiny.description.GithubSHA1' "$manifest")" == "$old_sha" ]] \
+  || inconsistent+=$'\n  GithubSHA1 disagrees with RemoteSha'
+[[ "$(jq -r '.files["app.R"].checksum' "$manifest")" == "$app_md5" ]] \
+  || inconsistent+=$'\n  app.R checksum is stale'
+[[ "$(jq -r '.files["README.md"].checksum' "$manifest")" == "$readme_md5" ]] \
+  || inconsistent+=$'\n  README.md checksum is stale'
+
+if [[ -z "$stale_files" && -z "$inconsistent" ]]; then
+  echo "the pinned commit installs the same app as master, manifest consistent"
+  $check_only && exit 0
+else
+  [[ -n "$stale_files" ]] && {
+    echo "the pinned commit predates these changes to the served app:"
+    echo "$stale_files" | sed 's/^/  /' | head -20
+  }
+  [[ -n "$inconsistent" ]] && echo "manifest is internally inconsistent:$inconsistent"
+  $check_only && { echo "DRIFT: run bump-pin.sh to bring the manifest up to date"; exit 1; }
+fi
 
 tmp="$(mktemp)"
 jq --arg sha "$sha" --arg version "$version" \
@@ -90,5 +108,5 @@ jq --arg sha "$sha" --arg version "$version" \
 jq -e . "$tmp" >/dev/null || { echo "produced invalid json, manifest untouched" >&2; exit 1; }
 mv "$tmp" "$manifest"
 
-echo "manifest re-pinned; commit it, push to master, then republish in Connect Cloud."
-echo "the app's sidebar footer should read: igvShiny $version"
+echo "manifest re-pinned; commit it and push to master - Connect republishes on"
+echo "its own from there. The app's sidebar footer should then read: igvShiny $version"

--- a/demo/posit-connect/manifest.json
+++ b/demo/posit-connect/manifest.json
@@ -2048,7 +2048,7 @@
       "checksum": "8b2248373ba81a33368853db6a623253"
     },
     "README.md": {
-      "checksum": "c3777fdf11908b7df0d9fd868d2e9835"
+      "checksum": "2b5abc9bdeddf32c08318d8567340033"
     }
   },
   "users": null

--- a/demo/posit-connect/manifest.json
+++ b/demo/posit-connect/manifest.json
@@ -1142,7 +1142,7 @@
       "description": {
         "Package": "igvShiny",
         "Title": "igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an\ninteractive tool for visualization and exploration integrated\ngenomic data)",
-        "Version": "1.9.25",
+        "Version": "1.9.35",
         "Date": "2026-07-17",
         "Authors@R": "c(\n    person(\"Paul\",\"Shannon\", role = c(\"aut\"), \n    email = \"paul.thurmond.shannon@gmail.com\"),\n    person(\"Arkadiusz\", \"Gladki\", role=c(\"aut\", \"cre\"), \n    email=\"gladki.arkadiusz@gmail.com\", comment = c(ORCID = \"0000-0002-7059-6378\")),\n    person(\"Karolina\",\"Scigocka\", role = c(\"aut\"),\n    email = \"scigocka.karolina@gmail.com\"),\n    person(\"Carolina\", \"Heimann\", role = c(\"ctb\"),\n    email = \"carolina.heimann@gmail.com\"),\n    person(\"Steffen\", \"Klasberg\", role = c(\"ctb\"),\n    email = \"klasberg@dkms-lab.de\"),\n    person(\"Vincent\", \"Carey\", role = c(\"ctb\"),\n    email = \"stvjc@channing.harvard.edu\"),\n    person(\"Parv\", \"Sachdeva\", role = c(\"ctb\"),\n    email = \"parv.sachdeva@sonomabio.com\"),\n    person(\"Mateusz\", \"Gladki\", role = c(\"ctb\"),\n    email = \"gladkiimateusz@gmail.com\")\n    )",
         "Description": "This package is a wrapper of Integrative Genomics Viewer (IGV).\n    It comprises an htmlwidget version of IGV. It can be used as a module \n    in Shiny apps. ",
@@ -1162,11 +1162,11 @@
         "RemoteRepo": "igvShiny",
         "RemoteUsername": "gladkia",
         "RemoteRef": "master",
-        "RemoteSha": "c2a1159e691d8f3846f6aaf6fcee2f9d0079d832",
+        "RemoteSha": "559c5c8fa07d410b8feb42e1c215574128f0a1c7",
         "GithubRepo": "igvShiny",
         "GithubUsername": "gladkia",
         "GithubRef": "master",
-        "GithubSHA1": "c2a1159e691d8f3846f6aaf6fcee2f9d0079d832",
+        "GithubSHA1": "559c5c8fa07d410b8feb42e1c215574128f0a1c7",
         "NeedsCompilation": "no",
         "Packaged": "2026-07-23 05:47:57 UTC; arek",
         "Author": "Paul Shannon [aut],\n  Arkadiusz Gladki [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-7059-6378>),\n  Karolina Scigocka [aut],\n  Carolina Heimann [ctb],\n  Steffen Klasberg [ctb],\n  Vincent Carey [ctb],\n  Parv Sachdeva [ctb],\n  Mateusz Gladki [ctb]",
@@ -2045,7 +2045,7 @@
   },
   "files": {
     "app.R": {
-      "checksum": "ebbddcd23bd375e7cba0ba3d44ecdb84"
+      "checksum": "8b2248373ba81a33368853db6a623253"
     },
     "README.md": {
       "checksum": "c3777fdf11908b7df0d9fd868d2e9835"


### PR DESCRIPTION
## Why

`demo/posit-connect/app.R` runs the demo out of the *installed* package, so the
commit pinned in `manifest.json` — not the branch — decides what the public demo
shows. Merging a demo change to master changes nothing until that pin moves.

The gap is invisible by construction: CI is green, the repo is correct, only the
live app is stale. It had been sitting on **1.9.25 / `c2a1159`** while master was
at 1.9.35 — ten versions.

## What

**`demo/posit-connect/bump-pin.sh`** — moves all six fields that have to stay in
step (`RemoteSha`, `GithubSHA1`, the recorded `Version`, and the two file
checksums) from one argument:

```bash
./demo/posit-connect/bump-pin.sh --check   # is the live demo behind? exit 1 = yes
./demo/posit-connect/bump-pin.sh           # re-pin to origin/master
./demo/posit-connect/bump-pin.sh <sha>     # or to one specific commit
```

`Version` is read from `DESCRIPTION` **at that commit**, not from the working
tree. An abbreviated SHA is refused: the GitHub API answers those with silence,
which reads exactly like a commit that does not exist. The JSON is validated
before the manifest is overwritten, and re-running is a no-op.

**`.github/workflows/connect-pin-check.yml`** — a push to master touching
`inst/demos/**` or `demo/posit-connect/**` runs `--check`, files a single
reminder issue when the pin is behind, and closes it once the pin catches up.
Modelled on `asset-url-check.yml`, including the dedup-by-title.

It **deploys nothing.** Republishing stays a click in Connect Cloud — the plan's
API is not something this PR assumes. Auto-committing a pin bump to a protected
master was the other option and is not worth the blast radius.

**The pin is also moved to `559c5c8` (1.9.35)** — the commit that rebuilt the
demos — so the live demo can finally show them.

## Docs

`demo/posit-connect/README.md` now separates the routine (script → commit →
republish) from the rare case (dependencies changed → `writeManifest`, which
reformats the whole file) and the one-time setup, including why the source
branch must be master.

Related: #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks to detect when the Connect Cloud demo is running an outdated version.
  * Added a script to update or verify the demo’s pinned version and associated file metadata.

* **Documentation**
  * Updated Connect Cloud deployment instructions with automated pinning, drift checks, dependency guidance and verification steps.

* **Maintenance**
  * Updated the demo package metadata to reference the latest pinned version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->