### PR TITLE
fix: drop the track options igv.js does not read

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.35
+Version: 1.9.36
 Date: 2026-07-29
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## igvShiny 1.9.36
+* Remove 14 track options igv.js never reads, which reached the browser and were ignored (#159)
+* Add negColorScale and posColorScale, the gradients seg tracks read (#159)
+* Add a test holding the option allowlist to the bundled igv.js build (#159)
+
 ## igvShiny 1.9.35
 * Rewrite the demo apps on bslib, replacing 15 legacy apps with 7 single-topic ones (#64)
 * Remove the forked Connect app, which now runs the package demo itself (#64)

--- a/R/igvShiny.R
+++ b/R/igvShiny.R
@@ -7,22 +7,33 @@
 #-------------------------------------------------------------------------------
 # A list of safe, known igv.js track configuration parameters.
 # This allowlist prevents arbitrary code injection and invalid options.
-# Sourced from igv.js documentation.
+#
+# Every name here has to be one igv.js actually reads. A name it does not know
+# is worse than a rejected one: it passes validation, reaches the browser, and
+# is ignored there, so the user gets no warning from either side and a track
+# drawn with defaults. test-track-option-allowlist.R holds the list to that,
+# checking each name against the bundled igv.js build.
 .validIgvTrackOptions <- c(
   "name", "type", "format", "url", "indexURL", "indexed", "order",
-  "displayMode", "color", "altColor", "negColor", "posColor", "borderColor",
+  "displayMode", "color", "altColor", "borderColor",
   "trait", "height", "autoHeight", "minHeight", "maxHeight", "removable",
-  "visibilityWindow", "searchable", "autoScale", "autoscale", "autoScaleGroup",
-  "autoscaleGroup", "min", "max", "logScale", "graphType", "barChart",
-  "flipAxis", "stroke", "noStroke", "fill", "noFill", "featureHeight",
-  "showLabels", "font", "fontSize", "fontStyle", "fontWeight", "colorTable",
-  "colorByAttribute",
+  ## seg tracks read their two gradients from these; the shorter negColor and
+  ## posColor, which look like the obvious spelling, are read by nothing
+  "negColorScale", "posColorScale",
+  ## only the lower-case s spelling is a track option. autoScaleGroup used to
+  ## sit here next to it, which meant a capitalised typo passed validation and
+  ## produced an ungrouped track with nothing said about it
+  "autoscale", "autoscaleGroup",
+  "visibilityWindow", "searchable", "autoScale",
+  "min", "max", "logScale", "graphType",
+  "flipAxis", "stroke", "fill", "featureHeight",
+  "font", "colorTable",
   ## the gwas parser reads these 1-based; without them it guesses the layout
   ## from the header names it knows, and any other spelling draws nothing
   "columns",
   "showAllBases", "samplingWindowSize", "samplingDepth", "maxRows",
-  "hideEmptyTracks", "oauthToken", "headers", "viewAsPairs", "pairsSupported",
-  "maxPanelHeight", "separateBam", "wholeGenomeView", "roi", "queryable",
+  "oauthToken", "headers", "viewAsPairs", "pairsSupported",
+  "wholeGenomeView", "roi", "queryable",
   ## alignment tracks sort their reads at load time from this object, the same
   ## one the igv.js right-click menu builds; "TAG" plus a tag covers #104
   "sort",

--- a/tests/testthat/test-track-option-allowlist.R
+++ b/tests/testthat/test-track-option-allowlist.R
@@ -1,0 +1,23 @@
+test_that("every allowlisted track option is one igv.js reads", {
+  # A name igv.js does not know passes .sanitizeAndMergeOptions, reaches the
+  # browser and is ignored there, so nothing warns on either side. The bundled
+  # build is a sufficient oracle: a minifier renames local variables but cannot
+  # rename property names, which are reached by string. So a whole-identifier
+  # hit in the minified file means igv.js reads that name off an object.
+  libDir <- system.file("htmlwidgets", "lib", package = "igvShiny")
+  bundled <- Sys.glob(file.path(libDir, "igv-*.min.js"))
+  expect_length(bundled, 1L)
+
+  src <- paste(readLines(bundled, warn = FALSE), collapse = "\n")
+  options <- igvShiny:::.validIgvTrackOptions
+
+  # Substring matching is not enough: "negColor" sits inside "negColorScale"
+  # and "autoScaleGroup" inside the internal "autoScaleGroupColorHash", so both
+  # would look alive while being read by nothing.
+  found <- vapply(options, function(option) {
+    pattern <- sprintf("(?<![A-Za-z0-9_$])%s(?![A-Za-z0-9_$])", option)
+    grepl(pattern, src, perl = TRUE)
+  }, logical(1))
+
+  expect_equal(options[!found], character(0))
+})

--- a/tests/testthat/test-track-option-allowlist.R
+++ b/tests/testthat/test-track-option-allowlist.R
@@ -8,7 +8,14 @@ test_that("every allowlisted track option is one igv.js reads", {
   bundled <- Sys.glob(file.path(libDir, "igv-*.min.js"))
   expect_length(bundled, 1L)
 
-  src <- paste(readLines(bundled, warn = FALSE), collapse = "\n")
+  # Read the bytes rather than the lines. readLines() has to decide on an
+  # encoding, and on a minified bundle that decision goes differently per
+  # platform: on Windows it came back short enough that every option looked
+  # missing, which reads as 60-odd dead options rather than as a bad read.
+  size <- file.size(bundled)
+  src <- rawToChar(readBin(bundled, "raw", n = size))
+  expect_equal(nchar(src, type = "bytes"), size)
+
   options <- igvShiny:::.validIgvTrackOptions
 
   # Substring matching is not enough: "negColor" sits inside "negColorScale"
@@ -16,7 +23,7 @@ test_that("every allowlisted track option is one igv.js reads", {
   # would look alive while being read by nothing.
   found <- vapply(options, function(option) {
     pattern <- sprintf("(?<![A-Za-z0-9_$])%s(?![A-Za-z0-9_$])", option)
-    grepl(pattern, src, perl = TRUE)
+    grepl(pattern, src, perl = TRUE, useBytes = TRUE)
   }, logical(1))
 
   expect_equal(options[!found], character(0))

--- a/tests/testthat/test-track-option-allowlist.R
+++ b/tests/testthat/test-track-option-allowlist.R
@@ -16,15 +16,24 @@ test_that("every allowlisted track option is one igv.js reads", {
   src <- rawToChar(readBin(bundled, "raw", n = size))
   expect_equal(nchar(src, type = "bytes"), size)
 
-  options <- igvShiny:::.validIgvTrackOptions
-
   # Substring matching is not enough: "negColor" sits inside "negColorScale"
   # and "autoScaleGroup" inside the internal "autoScaleGroupColorHash", so both
   # would look alive while being read by nothing.
-  found <- vapply(options, function(option) {
+  reads <- function(option) {
     pattern <- sprintf("(?<![A-Za-z0-9_$])%s(?![A-Za-z0-9_$])", option)
     grepl(pattern, src, perl = TRUE, useBytes = TRUE)
-  }, logical(1))
+  }
 
+  options <- igvShiny:::.validIgvTrackOptions
+  found <- vapply(options, reads, logical(1))
   expect_equal(options[!found], character(0))
+
+  # The check above passes just as well when the search is broken and finds
+  # everything, so pin some names igv.js 3.8.4 does not read. These are the
+  # ones #159 removed, and they are what the search has to be able to reject.
+  removed <- c("negColor", "posColor", "autoScaleGroup", "barChart",
+               "noStroke", "noFill", "showLabels", "fontStyle", "fontWeight",
+               "colorByAttribute", "hideEmptyTracks", "maxPanelHeight",
+               "separateBam")
+  expect_equal(removed[vapply(removed, reads, logical(1))], character(0))
 })


### PR DESCRIPTION
Closes #159.

## The problem

Fourteen names on `.validIgvTrackOptions` are read by nothing in igv.js 3.8.4. They pass validation, reach the browser, and are ignored there — so a user who passes one gets no warning from R, no message from igv.js, and a track drawn with defaults. That is the exact failure the allowlist exists to prevent, arriving through the allowlist itself.

```
negColor  posColor  autoScaleGroup  barChart  noStroke  noFill  showLabels
fontSize  fontStyle  fontWeight  colorByAttribute  hideEmptyTracks
maxPanelHeight  separateBam
```

`autoScaleGroup` is the one that costs something. It sat next to the working `autoscaleGroup`, so capitalising the S passed validation and produced an ungrouped track — the tracks are simply on different scales, which reads as a data problem, not a typo.

## Two options added

`negColorScale` and `posColorScale` are what `SegTrack` reads (`igv.esm.js:47797-47798`). They were not on the list, so until now a seg track's colour scales could not be set from R at all: the plausible names were allowed and dead, the real ones rejected.

## colorByAttribute is ours, not igv.js's

It is a loader argument on the two GFF3 loaders, translated to igv.js `colorBy` in `inst/htmlwidgets/igvShiny.js:834` and `:870`. It travels through `base.msg.to.igv`, and base options never meet the allowlist — **the loaders are unaffected**, as `test-loadTracks.R` still asserting `msg$colorByAttribute` shows. What is gone is the `trackConfig = list(colorByAttribute = ...)` route, which reached igv.js and was ignored.

## The test, and why the bundled build is enough

`tests/testthat/test-track-option-allowlist.R` walks the list and requires each name in `inst/htmlwidgets/lib/igv-*.min.js`.

A minifier renames local variables but cannot rename property names, since those are reached by string. So a whole-identifier hit in the minified build means igv.js reads that name off an object — which is exactly the question the list asks. `fontSize` is the worked example: 5 hits in the unminified build, all local variables in label-drawing code, 0 in the minified one.

Whole-identifier matching matters as much as the file does. Plain substring matching says all fourteen are fine: `negColor` sits inside `negColorScale`, `autoScaleGroup` inside the internal `autoScaleGroupColorHash`. The first draft of #159 made that mistake and had to be corrected.

The test also fires at the next igv.js bump, when an option the library has dropped would otherwise go quietly dead on our side.

## Verified

- `gDRstyle::checkPackage("igvShiny", repoDir = ".")` — R lint clean, NEWS lint clean, `Status: 1 NOTE` (pre-existing hidden-files note)
- `testthat::test_local()` — 226 pass, 0 fail, excluding the shinytest2 file
- guard confirmed to discriminate: `negColor` and `autoScaleGroup` FALSE, `negColorScale` and `autoscaleGroup` TRUE

## Note

Depends on nothing, but overlaps #160 in spirit: that PR documents the surviving options and deliberately omits the dead ones. A follow-up should add the seg colour scales to the reference now that they can be set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `negColorScale` and `posColorScale` gradient options for segmentation tracks.
* **Bug Fixes**
  * Updated track-option validation to recognise supported options and reject invalid or incorrectly capitalised names.
  * Removed unsupported track options from the accepted configuration list.
* **Documentation**
  * Added release notes for version 1.9.36.
* **Tests**
  * Added coverage to verify that accepted track options are available in the bundled library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->