### PR TITLE
docs: keep the vignette build off the network

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.38
+Version: 1.9.39
 Date: 2026-07-29
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## igvShiny 1.9.39
+* Prevent the getting-started vignette from reaching gladki.pl while the package builds (#158)
+
 ## igvShiny 1.9.38
 * Add loadSpliceJunctionTrackFromLocalData, writing junctions held in R as the bed igv.js reads (#103)
 * Support merged tracks in the startup track list, drawing junction arcs over a coverage track (#103)

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -377,9 +377,11 @@ customOptions[c("genomeName", "dataMode", "stockGenome")]
 The result goes to `igvShiny()` exactly like a stock genome specification.
 
 The same genome served over HTTP instead, which is what you want once the app
-runs somewhere other than your laptop:
+runs somewhere other than your laptop. `dataMode = "http"` makes
+`parseAndValidateGenomeSpec()` send a `HEAD` request to every URL, so this
+chunk is shown rather than run — building the vignette stays offline:
 
-```{r custom-genome-http}
+```{r custom-genome-http, eval=FALSE}
 base_url <- "https://gladki.pl/igvr/testFiles"
 
 remoteOptions <- parseAndValidateGenomeSpec(


### PR DESCRIPTION
## Problem

`vignettes/getting-started.Rmd`, chunk `custom-genome-http`, calls
`parseAndValidateGenomeSpec(dataMode = "http", ...)` on URLs under
`gladki.pl/igvr/testFiles`. That function sends an `httr::HEAD` to every URL,
and the chunk had no `eval=FALSE` — so **building the vignette reaches out to
the network**.

When the host failed to resolve on 2026-07-31, the ubuntu job on #158 died in
*Install dependencies pass 2*, at `* creating vignettes`, i.e. before
`R CMD check` even started:

```
Quitting from getting-started.Rmd:382-395 [custom-genome-http]
Error in `curl::curl_fetch_memory()`:
! Couldn't resolve host name [gladki.pl]
```

macOS and Windows built the same tree fine on the same commit, so this was a
single-runner DNS failure, not a regression. But the same request runs on the
Bioconductor build machines and in every user's `R CMD build` — one unreachable
host, and the package fails to build for reasons that have nothing to do with
the package.

## Fix

`eval=FALSE` on that one chunk, plus a sentence saying why it is shown rather
than run. The chunk is illustrative — its output is three fields echoed back —
so nothing is lost by not evaluating it. Credit to @M4teuszzGl4dki for spotting
it while diagnosing the red run on #158.

## Verification

`R CMD build` → `creating vignettes ... OK` (the exact step that failed), and
the generated `inst/doc/getting-started.html` shows the chunk source with no
output block following it, confirming it was not evaluated.

`checkVigChunkEval` is unaffected in practice: BiocCheck reports it as a NOTE,
and the CI step runs with `quit-with-status = TRUE`, which only fails on ERROR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the package to version 1.9.39.

* **Documentation**
  * Added release notes for version 1.9.39.
  * Updated the getting-started guide to clarify that custom genome URLs are validated with HEAD requests.
  * Prevented the custom-genome example from running during offline documentation builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->