### PR TITLE
fix: keep the roxygen examples off the network

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.9.39
+Version: 1.9.40
 Date: 2026-07-29
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## igvShiny 1.9.40
+* Switch the custom genome example to the sarsGenome files the package ships, keeping R CMD check offline
+* Wrap the remote GWAS example in donttest, since the GWASTrack constructor checks that the url resolves
+
 ## igvShiny 1.9.39
 * Prevent the getting-started vignette from reaching gladki.pl while the package builds (#158)
 

--- a/R/GWASTrack.R
+++ b/R/GWASTrack.R
@@ -123,6 +123,9 @@ setGeneric("getUrl",
 #'   )
 #' getUrl(track)
 #'
+#' # a remote gwas file: the constructor checks that the url resolves, so this
+#' # block reaches the network and stays out of R CMD check
+#' \donttest{
 #' url <- "https://gladki.pl/igvShiny/gwas_sample.tsv.gz"
 #' track <- GWASTrack(
 #'   "remote url gwas",
@@ -136,6 +139,7 @@ setGeneric("getUrl",
 #'   trackHeight = 100
 #' )
 #' getUrl(track)
+#' }
 #'
 #' # colors picked per chromosome, with "*" covering the rest
 #' track <- GWASTrack(

--- a/R/genomeSpec.R
+++ b/R/genomeSpec.R
@@ -100,23 +100,23 @@ get_css_genomes <- function(test = FALSE) {
 #' @examples
 #' genomeSpec <-
 #'   parseAndValidateGenomeSpec("hg38", "APOE")  # the simplest case
-#' base.url <-
-#'   "https://gladki.pl/igvr/testFiles/sarsGenome"
+#' # a custom genome, read from the files shipped with the package: every
+#' # resource is checked for existence, and "http" would check it over the
+#' # network on each R CMD check
+#' base.dir <-
+#'   system.file(package = "igvShiny", "extdata", "sarsGenome")
 #' fasta.file <-
-#'   sprintf("%s/%s", base.url, "Sars_cov_2.ASM985889v3.dna.toplevel.fa")
-#' fastaIndex.file <-
-#'   sprintf("%s/%s",
-#'           base.url,
-#'           "Sars_cov_2.ASM985889v3.dna.toplevel.fa.fai")
+#'   file.path(base.dir, "Sars_cov_2.ASM985889v3.dna.toplevel.fa")
+#' fastaIndex.file <- paste0(fasta.file, ".fai")
 #' annotation.file <-
-#'   sprintf("%s/%s", base.url, "Sars_cov_2.ASM985889v3.101.gff3")
+#'   file.path(base.dir, "Sars_cov_2.ASM985889v3.101.gff3")
 #' custom.genome.title <- "SARS-CoV-2"
 #' genomeOptions <-
 #'   parseAndValidateGenomeSpec(
 #'     genomeName = custom.genome.title,
 #'     initialLocus = "all",
 #'     stockGenome = FALSE,
-#'     dataMode = "http",
+#'     dataMode = "localFiles",
 #'     fasta = fasta.file,
 #'     fastaIndex = fastaIndex.file,
 #'     genomeAnnotation = annotation.file

--- a/man/GWASTrack-class.Rd
+++ b/man/GWASTrack-class.Rd
@@ -72,6 +72,9 @@ track <-
   )
 getUrl(track)
 
+# a remote gwas file: the constructor checks that the url resolves, so this
+# block reaches the network and stays out of R CMD check
+\donttest{
 url <- "https://gladki.pl/igvShiny/gwas_sample.tsv.gz"
 track <- GWASTrack(
   "remote url gwas",
@@ -85,6 +88,7 @@ track <- GWASTrack(
   trackHeight = 100
 )
 getUrl(track)
+}
 
 # colors picked per chromosome, with "*" covering the rest
 track <- GWASTrack(

--- a/man/parseAndValidateGenomeSpec.Rd
+++ b/man/parseAndValidateGenomeSpec.Rd
@@ -48,23 +48,23 @@ to test their genome specification for validity
 \examples{
 genomeSpec <-
   parseAndValidateGenomeSpec("hg38", "APOE")  # the simplest case
-base.url <-
-  "https://gladki.pl/igvr/testFiles/sarsGenome"
+# a custom genome, read from the files shipped with the package: every
+# resource is checked for existence, and "http" would check it over the
+# network on each R CMD check
+base.dir <-
+  system.file(package = "igvShiny", "extdata", "sarsGenome")
 fasta.file <-
-  sprintf("\%s/\%s", base.url, "Sars_cov_2.ASM985889v3.dna.toplevel.fa")
-fastaIndex.file <-
-  sprintf("\%s/\%s",
-          base.url,
-          "Sars_cov_2.ASM985889v3.dna.toplevel.fa.fai")
+  file.path(base.dir, "Sars_cov_2.ASM985889v3.dna.toplevel.fa")
+fastaIndex.file <- paste0(fasta.file, ".fai")
 annotation.file <-
-  sprintf("\%s/\%s", base.url, "Sars_cov_2.ASM985889v3.101.gff3")
+  file.path(base.dir, "Sars_cov_2.ASM985889v3.101.gff3")
 custom.genome.title <- "SARS-CoV-2"
 genomeOptions <-
   parseAndValidateGenomeSpec(
     genomeName = custom.genome.title,
     initialLocus = "all",
     stockGenome = FALSE,
-    dataMode = "http",
+    dataMode = "localFiles",
     fasta = fasta.file,
     fastaIndex = fastaIndex.file,
     genomeAnnotation = annotation.file


### PR DESCRIPTION
`parseAndValidateGenomeSpec()` and the `GWASTrack` constructor both validate what they are handed with `httr::http_error()`, so two `@examples` blocks queried `gladki.pl` on every `R CMD check` — ours, and Bioconductor's build machines.

This is the same failure #163 fixed in the vignette, in the second place it hides. Nothing masked it: `R/` carried no `\dontrun` and no `\donttest` at all, so every example ran, and the network call sits inside a package function rather than in the example text.

- The custom genome example reads `inst/extdata/sarsGenome` — the package already ships the same fasta, index and gff3 the example used to fetch, so it still runs, offline, with `dataMode = "localFiles"`.
- The remote GWAS example moves into `\donttest{}`; a remote source is the point of that block, and the local `data.frame` example above it covers the offline path.

The two functions above are the only network callers in `R/`; the `*FromURL` loaders pass their url to the browser and never fetch from R.

### Verification

`gDRstyle::checkPackage()` locally: NEWS lint and R lint clean, `[ FAIL 0 | WARN 0 | SKIP 1 | PASS 287 ]`, `checking examples ... OK`, `Status: 1 NOTE` (a local `.claude` directory, not in git).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the custom SARS-CoV-2 genome example to use bundled local files, improving offline package checks.
  * Marked the remote GWAS example as requiring network access during testing.
* **Chores**
  * Updated the package version to 1.9.40.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->