### PR TITLE
fix: re-pin the Connect demo to the commit that ships the showcase app

### DIFF
--- a/demo/posit-connect/manifest.json
+++ b/demo/posit-connect/manifest.json
@@ -1142,7 +1142,7 @@
       "description": {
         "Package": "igvShiny",
         "Title": "igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an\ninteractive tool for visualization and exploration integrated\ngenomic data)",
-        "Version": "1.9.35",
+        "Version": "1.9.41",
         "Date": "2026-07-17",
         "Authors@R": "c(\n    person(\"Paul\",\"Shannon\", role = c(\"aut\"), \n    email = \"paul.thurmond.shannon@gmail.com\"),\n    person(\"Arkadiusz\", \"Gladki\", role=c(\"aut\", \"cre\"), \n    email=\"gladki.arkadiusz@gmail.com\", comment = c(ORCID = \"0000-0002-7059-6378\")),\n    person(\"Karolina\",\"Scigocka\", role = c(\"aut\"),\n    email = \"scigocka.karolina@gmail.com\"),\n    person(\"Carolina\", \"Heimann\", role = c(\"ctb\"),\n    email = \"carolina.heimann@gmail.com\"),\n    person(\"Steffen\", \"Klasberg\", role = c(\"ctb\"),\n    email = \"klasberg@dkms-lab.de\"),\n    person(\"Vincent\", \"Carey\", role = c(\"ctb\"),\n    email = \"stvjc@channing.harvard.edu\"),\n    person(\"Parv\", \"Sachdeva\", role = c(\"ctb\"),\n    email = \"parv.sachdeva@sonomabio.com\"),\n    person(\"Mateusz\", \"Gladki\", role = c(\"ctb\"),\n    email = \"gladkiimateusz@gmail.com\")\n    )",
         "Description": "This package is a wrapper of Integrative Genomics Viewer (IGV).\n    It comprises an htmlwidget version of IGV. It can be used as a module \n    in Shiny apps. ",
@@ -1162,11 +1162,11 @@
         "RemoteRepo": "igvShiny",
         "RemoteUsername": "gladkia",
         "RemoteRef": "master",
-        "RemoteSha": "559c5c8fa07d410b8feb42e1c215574128f0a1c7",
+        "RemoteSha": "4b1389ddbd9ace1958a74dc522b98f6713574b05",
         "GithubRepo": "igvShiny",
         "GithubUsername": "gladkia",
         "GithubRef": "master",
-        "GithubSHA1": "559c5c8fa07d410b8feb42e1c215574128f0a1c7",
+        "GithubSHA1": "4b1389ddbd9ace1958a74dc522b98f6713574b05",
         "NeedsCompilation": "no",
         "Packaged": "2026-07-23 05:47:57 UTC; arek",
         "Author": "Paul Shannon [aut],\n  Arkadiusz Gladki [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-7059-6378>),\n  Karolina Scigocka [aut],\n  Carolina Heimann [ctb],\n  Steffen Klasberg [ctb],\n  Vincent Carey [ctb],\n  Parv Sachdeva [ctb],\n  Mateusz Gladki [ctb]",
@@ -2045,10 +2045,10 @@
   },
   "files": {
     "app.R": {
-      "checksum": "8b2248373ba81a33368853db6a623253"
+      "checksum": "fa0916c4747b5823d4206c193caa75e7"
     },
     "README.md": {
-      "checksum": "2b5abc9bdeddf32c08318d8567340033"
+      "checksum": "eb28e1bf91e2957d13775a8ca6efc931"
     }
   },
   "users": null


### PR DESCRIPTION
The Connect Cloud publish failed with `Runtime error / Unable to start the app` after #165 landed.

`demo/posit-connect/app.R` resolves the served app through the *installed* package:

```r
app.file <- system.file("showcase", "igvShinyDemo.R", package = "igvShiny")
```

#165 moved the flagship demo to `inst/showcase/`, but `manifest.json` still pinned 559c5c8 (1.9.35), where that path does not exist. Connect deployed the current `app.R` against the old package, `system.file()` returned `""`, and the guard added in #156 stopped the app at startup. The pin gap used to be silent - stale app, green deploy; #165 made it fatal.

`bump-pin.sh` re-pins to 4b1389d (1.9.41) and refreshes the `app.R` / `README.md` checksums that went stale in the same PR.

```
pinned:  1.9.41  4b1389d
target:  1.9.41  4b1389d
the pinned commit installs the same app as master, manifest consistent
```

Manifest only - no package code touched, so no version bump or NEWS entry (same shape as #157).

Closes #162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to version 1.9.41.
  * Refreshed associated commit references and file integrity checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->